### PR TITLE
修复 后台指令 文字描叙重复

### DIFF
--- a/Gui/BGKeyGui.ahk
+++ b/Gui/BGKeyGui.ahk
@@ -79,9 +79,6 @@ class BGKeyGui {
         PosX := 20
         PosY += 20
         {
-
-            MyGui.Add("Text", Format("x{} y{} h{}", PosX, PosY, 20), GetLang("请从下面按钮中选择按键："))
-
             PosX := 20
             PosY += 20
             con := MyGui.Add("Checkbox", Format("x{} y{} h{}", PosX, PosY, 20), "Esc")


### PR DESCRIPTION
修复「请从下面按钮中选择按键：」重复了两次
<img width="1919" height="660" alt="SnowShot_2025-12-22_08-24-28" src="https://github.com/user-attachments/assets/3c8ace9e-4444-4ec3-91e1-cf8e382e50a7" />
<img width="1875" height="630" alt="SnowShot_2025-12-22_08-32-58" src="https://github.com/user-attachments/assets/d880c328-bfeb-4a67-9ae9-72362cbb0d2f" />
