### PR TITLE
修复索引问题

### DIFF
--- a/Main/Util/MacroUtil.ahk
+++ b/Main/Util/MacroUtil.ahk
@@ -584,7 +584,7 @@ OnSubMacro(tableItem, cmd, index) {
     macroTableIndex := Data.MacroType == "当前宏" ? tableItem.Index : GetTableIndex(Data.MacroType)
     macroItem := Data.MacroType == "当前宏" ? tableItem : MySoftData.TableInfo[macroTableIndex]
 
-    IsAbnormal := macroItem.SerialArr.Length < Data.Index || macroItem.SerialArr[Data.Index] != Data.MacroSerial
+    IsAbnormal := macroItem.SerialArr.Length < macroIndex || macroItem.SerialArr[macroIndex] != Data.MacroSerial
     if (Data.MacroType != "当前宏" && IsAbnormal) {
         loop macroItem.ModeArr.Length {
             if (Data.MacroSerial == macroItem.SerialArr[A_Index]) {


### PR DESCRIPTION
该代码没有使用正确的索引macroIndex

https://github.com/zclucas/RMT/blob/5e6a123e2696f5f33006c9f405418627778d0a14/Main/Util/MacroUtil.ahk#L583-L587

应修改为
```
IsAbnormal := macroItem.SerialArr.Length < macroIndex || macroItem.SerialArr[macroIndex] != Data.MacroSerial
```