### PR TITLE
Fix: 最小化模式启动时会打开应用程序图标的问题

### DIFF
--- a/Main/UIUtil.ahk
+++ b/Main/UIUtil.ahk
@@ -33,6 +33,7 @@ OnOpen() {
 
     if (MySoftData.IsMinStart) {
         MySoftData.IsMinStart := false
+        MySoftData.MyGui.Hide()
         return
     }
 


### PR DESCRIPTION
<img width="262" height="261" alt="Snipaste_2026-03-29_23-40-07" src="https://github.com/user-attachments/assets/7dd92203-8bcb-403f-80f2-9f9ca13d4e23" />


修复后不会出现该图标