### PR TITLE
Fix: 按键替换的热键(1/2/3/4/5/6/7/8)冲突

### DIFF
--- a/Main/BindUtil.ahk
+++ b/Main/BindUtil.ahk
@@ -461,10 +461,10 @@ BindTabHotKey() {
             }
             else {
                 if (actionArr[1] != "")
-                    Hotkey(key, actionArr[1])
+                    Hotkey(key, actionArr[1], "On")
 
                 if (actionArr[2] != "")
-                    Hotkey(key " up", actionArr[2])
+                    Hotkey(key " up", actionArr[2], "On")
             }
 
             if (frontInfo != "") {


### PR DESCRIPTION
在启用热键后就可以使用，但是按照现有逻辑，按键替换的优先级是最低的，所以按键宏/菜单宏等是优先触发的，在用户配置时应该注意这一点，避免使用同一热键