### PR TITLE
修復起動時 MySoftData 沒有 Gui 屬性的報錯問題

### DIFF
--- a/Main/UIUtil.ahk
+++ b/Main/UIUtil.ahk
@@ -33,7 +33,7 @@ OnOpen() {
 
     if (MySoftData.IsMinStart) {
         MySoftData.IsMinStart := false
-        MySoftData.Gui.Hide()
+        MySoftData.MyGui.Hide()
         return
     }
 


### PR DESCRIPTION
在该项目中，`SoftData` 类定义的属性名称为 `MyGui` 而非 `Gui`。在 `Main\UIUtil.ahk` 的 `OnOpen` 函数中，原本使用了错误的属性名 `MySoftData.Gui`，导致了“无此属性”的运行时错误。

**修复内容：**
将 `Main\UIUtil.ahk` 第 36 行的 `MySoftData.Gui.Hide()` 修正为 `MySoftData.MyGui.Hide()`。

此更改确保了代码与 `Main\DataClass.Ahk` 中定义的 `SoftData` 类结构保持一致，消除了在以最小化模式启动时尝试隐藏主界面而产生的错误。