### PR TITLE
Fix: 修复开机自启导致的托盘缺失问题

### DIFF
--- a/Main/UIUtil.ahk
+++ b/Main/UIUtil.ahk
@@ -662,6 +662,12 @@ AddRewardUI(index) {
 
 ; 系统托盘优化
 CustomTrayMenu() {
+    loop 50 {
+        if(WinExist("ahk_class Shell_TrayWnd")){
+            break
+        }
+        Sleep(100)
+    }
     A_TrayMenu.Insert("&Suspend Hotkeys", GetLang("显示窗口"), (*) => RefreshGui())
     A_TrayMenu.Insert("&Suspend Hotkeys", GetLang("休眠"), (*) => OnSuspendHotkey())
     A_TrayMenu.Delete("&Pause Script")


### PR DESCRIPTION
在系统就绪后在执行托盘初始化(最长等待5s)