### PR TITLE
Fix: 修复罗技驱动重复按键导致的假死问题

### DIFF
--- a/Main/Util/PresssKeyUtil.ahk
+++ b/Main/Util/PresssKeyUtil.ahk
@@ -138,12 +138,19 @@ SendGameMouseKey(key, state, tableItem, index) {
 SendLogicKey(Key, state, tableItem, index) {
     if (!InitLogitechGHubNew())
         return
+    if (MySoftData.OnlyDownKeyMap.Has(Key))
+        return
+
+    ; 去重检查：防止连续发送相同的按键状态导致DLL假死
+    if (state == 1 && tableItem.HoldKeyArr[index].Has(Key))
+        return
+    if (state == 0 && !tableItem.HoldKeyArr[index].Has(Key))
+        return
+
     Symbol := state == 1 ? "down" : "up"
     keySymbol := "{Blind}{" key " " Symbol "}"
     IbSend(keySymbol)
 
-    if (MySoftData.OnlyDownKeyMap.Has(Key))
-        return
     if (state == 1) {
         tableItem.HoldKeyArr[index][Key] := "Logic"
     }


### PR DESCRIPTION
由于只有6个报告位，满了就炸，导致假死，需要在调用前加一个判断


                if (keydown) {
                    for (int i = 0; i < 6; i++) {
                        if (keyboard_report.keys[i] == 0) {
                            keyboard_report.keys[i] = usage;
                            break;
                        }
                    }
                    //full
                }
https://github.com/Chaoses-Ib/IbInputSimulator/blob/355cb1b1ffe935de856c419b7ff7ff260d5ffc64/Simulator/include/IbInputSimulator/SendTypes/Logitech.hpp#L362-L370