### PR TITLE
refactor(timing): 将旧的定时类型(2,3,4,5)迁移到自定义类型

### DIFF
--- a/Gui/TimingGui.ahk
+++ b/Gui/TimingGui.ahk
@@ -30,7 +30,12 @@ class TimingGui {
 
         this.StartTimeCon.Value := this.Data.StartTime
         this.EndTimeCon.Value := this.Data.EndTime
-        this.TypeCon.Value := this.Data.Type
+
+        ; Map internal Type to UI index
+        typeMap := Map(1, 1, 6, 2, 7, 3)
+        uiIndex := typeMap.Has(this.Data.Type) ? typeMap[this.Data.Type] : 3
+        this.TypeCon.Value := uiIndex
+
         this.CustomIntervalCon.Value := this.Data.CustomInterval
         this.IntervalUnitCon.Value := this.Data.CustomUnit
     }
@@ -56,15 +61,14 @@ class TimingGui {
         con := MyGui.Add("Text", Format("x{} y{}", PosX, PosY), GetLang("定时类型："))
         con.Focus()
         PosX += 80
-        this.TypeCon := MyGui.Add("DropDownList", Format("x{} y{} w120", PosX, PosY - 3), GetLangArr(["单次", "每小时", "每天", "每周",
-            "每月", "软件启动时","自定义"]))
+        this.TypeCon := MyGui.Add("DropDownList", Format("x{} y{} w120", PosX, PosY - 3), GetLangArr(["单次", "软件启动时", "自定义"]))
         this.TypeCon.OnEvent("Change", (*) => this.OnChangeType())
         PosX += 200
         this.IntervalLabelCon := MyGui.Add("Text", Format("x{} y{}", PosX, PosY), GetLang("每次间隔："))
         PosX += 80
         this.CustomIntervalCon := MyGui.Add("Edit", Format("x{} y{} w110", PosX, PosY - 3), "")
         PosX += 115
-        this.IntervalUnitCon := MyGui.Add("DropDownList", Format("x{} y{} w80", PosX, PosY -3), GetLangArr(["秒", "分钟", "小时", "天", "周"]))
+        this.IntervalUnitCon := MyGui.Add("DropDownList", Format("x{} y{} w80", PosX, PosY -3), GetLangArr(["秒", "分钟", "小时", "天", "周", "月"]))
 
         PosX := 250
         PosY += 40
@@ -93,7 +97,7 @@ class TimingGui {
     }
 
     OnChangeType() {
-        isCustom := this.TypeCon.Value == 7
+        isCustom := this.TypeCon.Value == 3
 
         this.IntervalLabelCon.Visible := isCustom
         this.CustomIntervalCon.Visible := isCustom
@@ -113,7 +117,11 @@ class TimingGui {
         Data := this.Data
         Data.StartTime := FormatTime(this.StartTimeCon.Value, "yyyyMMddHHmmss")
         Data.EndTime := this.EndTimeCon.Value == "" ? "" : FormatTime(this.EndTimeCon.Value, "yyyyMMddHHmmss")
-        Data.Type := this.TypeCon.Value
+
+        ; Map UI index back to internal Type
+        typeMap := [1, 6, 7]
+        Data.Type := typeMap[this.TypeCon.Value]
+
         Data.CustomInterval := this.CustomIntervalCon.Value
         Data.CustomUnit := this.IntervalUnitCon.Value
         saveStr := JSON.stringify(Data, 0)

--- a/Gui/TimingGui.ahk
+++ b/Gui/TimingGui.ahk
@@ -30,12 +30,7 @@ class TimingGui {
 
         this.StartTimeCon.Value := this.Data.StartTime
         this.EndTimeCon.Value := this.Data.EndTime
-
-        ; Map internal Type to UI index
-        typeMap := Map(1, 1, 6, 2, 7, 3)
-        uiIndex := typeMap.Has(this.Data.Type) ? typeMap[this.Data.Type] : 3
-        this.TypeCon.Value := uiIndex
-
+        this.TypeCon.Value := this.Data.Type
         this.CustomIntervalCon.Value := this.Data.CustomInterval
         this.IntervalUnitCon.Value := this.Data.CustomUnit
     }
@@ -117,11 +112,7 @@ class TimingGui {
         Data := this.Data
         Data.StartTime := FormatTime(this.StartTimeCon.Value, "yyyyMMddHHmmss")
         Data.EndTime := this.EndTimeCon.Value == "" ? "" : FormatTime(this.EndTimeCon.Value, "yyyyMMddHHmmss")
-
-        ; Map UI index back to internal Type
-        typeMap := [1, 6, 7]
-        Data.Type := typeMap[this.TypeCon.Value]
-
+        Data.Type := this.TypeCon.Value
         Data.CustomInterval := this.CustomIntervalCon.Value
         Data.CustomUnit := this.IntervalUnitCon.Value
         saveStr := JSON.stringify(Data, 0)

--- a/Main/TimingUtil.ahk
+++ b/Main/TimingUtil.ahk
@@ -210,41 +210,29 @@ CalculateNextStamp(Data, baseStamp) {
         case 1:
             return spanSeconds < 0 ? start : 0
 
-        case 2, 3, 4, 7:
-            interval := GetTimingInterval(Data)
+        case 7:
+            if (Data.CustomUnit == 6) { ; Month
+                if (spanSeconds < 0)
+                    return start
 
-            if (spanSeconds < 0)
-                return start
+                startTimeStr := DateAdd("19700101000000", start, "Seconds")
+                baseTimeStr := DateAdd("19700101000000", baseStamp, "Seconds")
 
-            count := Floor(spanSeconds / interval)
-            return start + (count + 1) * interval
+                monthsDiff := DateDiff(baseTimeStr, startTimeStr, "Months")
+                interval := Data.CustomInterval
 
-        case 5:
-            if (spanSeconds < 0)
-                return start
+                k := (monthsDiff // interval) + 1
+                nextTimeStr := DateAdd(startTimeStr, k * interval, "Months")
+                return TimeStrToStamp(nextTimeStr)
+            } else {
+                interval := GetTimingInterval(Data)
 
-            t := DateAdd("19700101000000", baseStamp, "Seconds")
-            baseStr := FormatTime(t, "yyyyMMddHHmmss")
+                if (spanSeconds < 0)
+                    return start
 
-            timeSuffix := SubStr(Data.StartTime, 7)
-            targetStr := SubStr(baseStr, 1, 6) timeSuffix
-            target := TimeStrToStamp(targetStr)
-
-            if (baseStamp < target)
-                return target
-
-            year := SubStr(baseStr, 1, 4)
-            month := Number(SubStr(baseStr, 5, 2))
-
-            ++month
-            if (month > 12)
-                month := 1, ++year
-
-            nextStr := Format("{:04}{:02}", year, month) timeSuffix
-            return TimeStrToStamp(nextStr)
-
-        default:
-            return 0
+                count := Floor(spanSeconds / interval)
+                return start + (count + 1) * interval
+            }
     }
 }
 
@@ -257,12 +245,8 @@ TimeStrToStamp(timeStr) {
 }
 
 GetTimingInterval(Data) {
-    IntervalMap := Map(2, 3600, 3, 86400, 4, 604800)
-    if (IntervalMap.Has(Data.Type))
-        return IntervalMap[Data.Type]
-
-    MultiplierMap := [1, 60, 3600, 86400, 604800]
-    return Data.CustomInterval * MultiplierMap[Data.CustomUnit]
+    IntervalMap := [1, 60, 3600, 86400, 604800]
+    return Data.CustomInterval * IntervalMap[Data.CustomUnit]
 }
 
 TimingCheckItemIfValid(tableItem, index) {

--- a/Main/TimingUtil.ahk
+++ b/Main/TimingUtil.ahk
@@ -54,8 +54,6 @@ class TimingScheduler {
                 continue
 
             Data := GetMacroCMDData(tableItem.TimingSerialArr[index])
-            if (Data == "")
-                continue
 
             if (Data.EndStamp && now >= Data.EndStamp)
                 continue
@@ -96,9 +94,6 @@ class TimingScheduler {
             index := item.index
 
             Data := GetMacroCMDData(tableItem.TimingSerialArr[index])
-            if (Data == "")
-                continue
-
             shouldTrigger := true
 
             if ((frontInfo := GetItemFrontInfo(tableItem, index)) != "") {
@@ -193,7 +188,7 @@ NormalizeTimingData(tableItem) {
     for index, _ in tableItem.ModeArr {
 
         Data := GetMacroCMDData(tableItem.TimingSerialArr[index])
-        if (Data == "" || Data.HasOwnProp("StartStamp"))
+        if (Data.HasOwnProp("StartStamp"))
             continue
 
         Data.StartStamp := TimeStrToStamp(Data.StartTime)
@@ -210,7 +205,7 @@ CalculateNextStamp(Data, baseStamp) {
         case 1:
             return spanSeconds < 0 ? start : 0
 
-        case 7:
+        case 3:
             if (Data.CustomUnit == 6) { ; Month
                 if (spanSeconds < 0)
                     return start
@@ -265,7 +260,7 @@ HandleOnSoftStart(tableItem) {
             continue
 
         Data := GetMacroCMDData(tableItem.TimingSerialArr[index])
-        if (Data != "" && Data.Type == 6)
+        if (Data.Type == 2)
             TriggerMacroHandler(tableItem.Index, index)
     }
 }

--- a/Main/Util/FixCompatUtil.ahk
+++ b/Main/Util/FixCompatUtil.ahk
@@ -210,10 +210,10 @@ CompatTiming(filePath) {
             curFix := true
         }
 
-        ; Migrate old types (2,3,4,5) to Custom (7)
+        ; Migrate old types to new scheme (1: Once, 2: Startup, 3: Custom)
         if (Data.Type >= 2 && Data.Type <= 5) {
             oldType := Data.Type
-            Data.Type := 7
+            Data.Type := 3 ; Custom
             Data.CustomInterval := 1
             if (oldType == 2) ; Hourly
                 Data.CustomUnit := 3
@@ -223,6 +223,12 @@ CompatTiming(filePath) {
                 Data.CustomUnit := 5
             else if (oldType == 5) ; Monthly
                 Data.CustomUnit := 6
+            curFix := true
+        } else if (Data.Type == 6) { ; Old Startup
+            Data.Type := 2
+            curFix := true
+        } else if (Data.Type == 7) { ; Old Custom
+            Data.Type := 3
             curFix := true
         }
 

--- a/Main/Util/FixCompatUtil.ahk
+++ b/Main/Util/FixCompatUtil.ahk
@@ -210,6 +210,22 @@ CompatTiming(filePath) {
             curFix := true
         }
 
+        ; Migrate old types (2,3,4,5) to Custom (7)
+        if (Data.Type >= 2 && Data.Type <= 5) {
+            oldType := Data.Type
+            Data.Type := 7
+            Data.CustomInterval := 1
+            if (oldType == 2) ; Hourly
+                Data.CustomUnit := 3
+            else if (oldType == 3) ; Daily
+                Data.CustomUnit := 4
+            else if (oldType == 4) ; Weekly
+                Data.CustomUnit := 5
+            else if (oldType == 5) ; Monthly
+                Data.CustomUnit := 6
+            curFix := true
+        }
+
         ; Force re-calculation of relative stamps
         if (curFix || Data.HasOwnProp("StartStamp")) {
             if (Data.HasOwnProp("StartStamp")) {


### PR DESCRIPTION
将旧的定时类型(2,3,4,5)迁移到自定义类型，统一使用CustomInterval和CustomUnit
- 更新UI界面中的类型选择映射，移除已废弃的固定间隔选项
- 修改时间间隔计算方法，统一通过自定义单位映射表进行计算
- 移除重复的时间间隔计算逻辑，优化月度间隔的特殊处理