### PR TITLE
refactor: 统一开机自启相关逻辑为布尔值

### DIFF
--- a/Main/AssetUtil.ahk
+++ b/Main/AssetUtil.ahk
@@ -401,13 +401,13 @@ LoadMainSetting() {
     ToolCheckInfo.RecordMouseTrailInterval := IniRead(IniFile, IniSection, "MouseTrailInterval", 300)
     ToolCheckInfo.RecordJoyInterval := IniRead(IniFile, IniSection, "RecordJoyInterval", 50)
     ToolCheckInfo.OCRTypeValue := IniRead(IniFile, IniSection, "OCRType", 1)
-    MySoftData.IsBootStart := IniRead(IniFile, IniSection, "IsBootStart", 0)
-    if (MySoftData.IsBootStart == "false")
-        MySoftData.IsBootStart := 0
-    else if (MySoftData.IsBootStart == "true")
-        MySoftData.IsBootStart := 1
+    MySoftData.IsBootStart := IniRead(IniFile, IniSection, "IsBootStart", false)
+    if (MySoftData.IsBootStart == 1 || MySoftData.IsBootStart == 2)
+        MySoftData.IsBootStart := true
+    else if (MySoftData.IsBootStart == "false" || MySoftData.IsBootStart == 0)
+        MySoftData.IsBootStart := false
     else
-        MySoftData.IsBootStart := Integer(MySoftData.IsBootStart)
+        MySoftData.IsBootStart := !!MySoftData.IsBootStart
     MySoftData.IsAdminStart := IniRead(IniFile, IniSection, "IsAdminStart", false)
     MySoftData.ShowSplitLine := IniRead(IniFile, IniSection, "ShowSplitLine", false)
     MySoftData.FixedMenuWheel := IniRead(IniFile, IniSection, "FixedMenuWheel", false)

--- a/Main/DataClass.Ahk
+++ b/Main/DataClass.Ahk
@@ -203,7 +203,7 @@ class SoftData {
         this.ToolTipText := ""          ;临时提示文本
         this.ToolTipEndTime := ""       ;临时提示结束时间
         this.AgreeAgreement := false    ;同意协议
-        this.IsBootStart := 0             ;开机自启（0=否 1=是 2=管理员）
+        this.IsBootStart := false        ;开机自启
         this.IsAdminStart := false        ;管理员启动
         this.ShowSplitLine := false     ;显示分割线
         this.FixedMenuWheel := false    ;固定菜单轮

--- a/Main/RMTUtil.ahk
+++ b/Main/RMTUtil.ahk
@@ -24,7 +24,7 @@ OnSaveSetting(*) {
     IniWrite(MySoftData.SuspendHotkeyCtrl.Value, IniFile, IniSection, "SuspendHotkey")
     IniWrite(MySoftData.PauseHotkeyCtrl.Value, IniFile, IniSection, "PauseHotkey")
     IniWrite(MySoftData.KillMacroHotkeyCtrl.Value, IniFile, IniSection, "KillMacroHotkey")
-    IniWrite(MySoftData.BootStartCtrl.Value - 1, IniFile, IniSection, "IsBootStart")
+    IniWrite(MySoftData.BootStartCtrl.Value, IniFile, IniSection, "IsBootStart")
     IniWrite(MySoftData.SplitLineCtrl.Value, IniFile, IniSection, "ShowSplitLine")
     IniWrite(MySoftData.FixedMenuWheelCtrl.Value, IniFile, IniSection, "FixedMenuWheel")
     IniWrite(MySoftData.ModalSubGuiCtrl.Value, IniFile, IniSection, "IsModalSubGui")
@@ -966,7 +966,7 @@ HandleOpenArg() {
             MySoftData.IsMinStart := true
             continue
         }
-        if (arg == "-elevate") {
+        if (arg == "-admin") {
             if (!A_IsAdmin) {
                 ElevateToAdmin()
             }
@@ -979,7 +979,7 @@ ElevateToAdmin() {
     args := ""
     loop A_Args.Length {
         arg := A_Args[A_Index]
-        if (arg != "-elevate")
+        if (arg != "-admin")
             args .= ' "' arg '"'
     }
     try {

--- a/Main/UIUtil.ahk
+++ b/Main/UIUtil.ahk
@@ -491,41 +491,45 @@ AddSettingUI(index) {
     posY += 40
     con := AddTableControl("GroupBox", Format("x{} y{} w870 h140", posX + 10, posY), GetLang("开关选项"), tableItem)
     tableItem.AllGroup.Push(con)
-    posY += 30
 
-    con := AddTableControl("CheckBox", Format("x{} y{} -Wrap w15", posX + 25, posY), "", tableItem)
+    posY += 30
+    con := AddTableControl("CheckBox", Format("x{} y{}", posX + 25, posY), GetLang("开机自启"), tableItem)
+    MySoftData.BootStartCtrl := con
+    MySoftData.BootStartCtrl.Value := MySoftData.IsBootStart
+    MySoftData.BootStartCtrl.OnEvent("Click", OnBootStartChanged)
+
+    con := AddTableControl("CheckBox", Format("x{} y{}", posX + 315, posY), GetLang("管理员启动"), tableItem)
+    MySoftData.AdminStartCtrl := con
+    MySoftData.AdminStartCtrl.Value := MySoftData.IsAdminStart
+    MySoftData.AdminStartCtrl.OnEvent("Click", OnAdminStartChanged)
+
+    con := AddTableControl("CheckBox", Format("x{} y{} -Wrap w15", posX + 635, posY), "", tableItem)
     MySoftData.CMDTipCtrl := con
     MySoftData.CMDTipCtrl.Value := MySoftData.CMDTip
-    con := AddTableControl("Button", Format("x{} y{}", posX + 25 + 15, posY - 5), GetLang("指令显示"), tableItem)
+    con := AddTableControl("Button", Format("x{} y{}", posX +635 + 15, posY - 5), GetLang("指令显示"), tableItem)
     con.OnEvent("Click", (*) => OnEditCMDTipGui())
 
-    con := AddTableControl("Button", Format("x{} y{} w{}", posX + 315, posY - 5, 100), GetLang("录制选项"), tableItem)
+    posY += 40
+    con := AddTableControl("Button", Format("x{} y{} w{}", posX + 25, posY - 5, 100), GetLang("录制选项"), tableItem)
     con.OnEvent("Click", OnClickToolRecordSettingBtn)
 
-    con := AddTableControl("CheckBox", Format("x{} y{}", posX + 635, posY), GetLang("无变量提醒"), tableItem)
+    con := AddTableControl("CheckBox", Format("x{} y{}", posX + 315, posY), GetLang("无变量提醒"), tableItem)
     MySoftData.NoVariableTipCtrl := con
     MySoftData.NoVariableTipCtrl.Value := MySoftData.NoVariableTip
 
-    posY += 40
-
-    con := AddTableControl("CheckBox", Format("x{} y{}", posX + 25, posY), GetLang("菜单轮位置固定"), tableItem)
+    con := AddTableControl("CheckBox", Format("x{} y{}", posX + 635, posY), GetLang("菜单轮位置固定"), tableItem)
     MySoftData.FixedMenuWheelCtrl := con
     MySoftData.FixedMenuWheelCtrl.Value := MySoftData.FixedMenuWheel
     MySoftData.FixedMenuWheelCtrl.OnEvent("Click", OnMenuWheelPosChanged)
 
-    con := AddTableControl("CheckBox", Format("x{} y{}", posX + 315, posY), GetLang("分割线"), tableItem)
+    posY += 40
+    con := AddTableControl("CheckBox", Format("x{} y{}", posX + 25, posY), GetLang("分割线"), tableItem)
     MySoftData.SplitLineCtrl := con
     MySoftData.SplitLineCtrl.Value := MySoftData.ShowSplitLine
 
-    con := AddTableControl("CheckBox", Format("x{} y{}", posX + 635, posY), GetLang("模态子窗口"), tableItem)
+    con := AddTableControl("CheckBox", Format("x{} y{}", posX + 315, posY), GetLang("模态子窗口"), tableItem)
     MySoftData.ModalSubGuiCtrl := con
     MySoftData.ModalSubGuiCtrl.Value := MySoftData.IsModalSubGui
-
-    posY += 40
-    con := AddTableControl("CheckBox", Format("x{} y{}", posX + 25, posY), GetLang("管理员启动"), tableItem)
-    MySoftData.AdminStartCtrl := con
-    MySoftData.AdminStartCtrl.Value := MySoftData.IsAdminStart
-    MySoftData.AdminStartCtrl.OnEvent("Click", OnAdminStartChanged)
 
     posY += 40
     con := AddTableControl("GroupBox", Format("x{} y{} w870 h100", posX + 10, posY), GetLang("下拉框选项"), tableItem)
@@ -561,11 +565,6 @@ AddSettingUI(index) {
     MySoftData.KeyDownDownCon.Value := MySoftData.KeyDownDownType
     Con := AddTableControl("Button", Format("x{} y{} h27", posX + 231, posY - 4), "?", tableItem)
     Con.OnEvent("Click", OnClickKeyDownDownHelpBtn)
-
-    AddTableControl("Text", Format("x{} y{}", posX + 315, posY), GetLang("开机自启："), tableItem)
-    con := AddTableControl("DropDownList", Format("x{} y{} w120", posX + 390, posY - 4), GetLangArr(["否", "是", "管理员"]), tableItem)
-    MySoftData.BootStartCtrl := con
-    MySoftData.BootStartCtrl.Value := MySoftData.IsBootStart + 1
 
     posY += 30
     tableItem.UnderPosY := posY

--- a/Main/Util/MacroUtil.ahk
+++ b/Main/Util/MacroUtil.ahk
@@ -965,17 +965,17 @@ OnClearToolText(*) {
 
 OnBootStartChanged(*) {
     global MySoftData
-    MySoftData.IsBootStart := MySoftData.BootStartCtrl.Value - 1
+    MySoftData.IsBootStart := MySoftData.BootStartCtrl.Value
     regPath := "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run"
     softPath := A_ScriptFullPath
-    if (MySoftData.IsBootStart == 0) {
+    if (!MySoftData.IsBootStart) {
         RegDelete(regPath, "RMT")
     }
-    else if (MySoftData.IsBootStart == 1) {
-        RegWrite(softPath " -min", "REG_SZ", regPath, "RMT")
+    else if (MySoftData.IsAdminStart) {
+        RegWrite(softPath " -min -admin", "REG_SZ", regPath, "RMT")
     }
     else {
-        RegWrite(softPath " -min -elevate", "REG_SZ", regPath, "RMT")
+        RegWrite(softPath " -min", "REG_SZ", regPath, "RMT")
     }
     IniWrite(MySoftData.IsBootStart, IniFile, IniSection, "IsBootStart")
 }
@@ -984,6 +984,14 @@ OnAdminStartChanged(*) {
     global MySoftData
     MySoftData.IsAdminStart := MySoftData.AdminStartCtrl.Value
     IniWrite(MySoftData.IsAdminStart, IniFile, IniSection, "IsAdminStart")
+    if (MySoftData.IsBootStart) {
+        regPath := "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run"
+        softPath := A_ScriptFullPath
+        if (MySoftData.IsAdminStart)
+            RegWrite(softPath " -min -admin", "REG_SZ", regPath, "RMT")
+        else
+            RegWrite(softPath " -min", "REG_SZ", regPath, "RMT")
+    }
 }
 
 OnMenuWheelPosChanged(*) {


### PR DESCRIPTION
1.  将SoftData类的IsBootStart字段从数字改为布尔类型
2.  重构开机自启注册表写入逻辑，区分普通启动和管理员启动
3.  更新UI控件类型为复选框，替换原有的下拉选择框
4.  统一配置读写的类型处理逻辑
5.  修正启动参数的标识从-elevate为-admin