### PR TITLE
refactor: 重构热键管理逻辑，替换旧的绑定方案

### DIFF
--- a/Gui/MacroEditGui.ahk
+++ b/Gui/MacroEditGui.ahk
@@ -29,7 +29,6 @@ class MacroEditGui {
     static Hotkeys := ["f5", "f6", "delete", "numpaddot"]
 
     __new() {
-        WindowHotkeyManager.Register(this, MacroEditGui.Hotkeys, this.OnSoftKey.Bind(this))
         this.ParentTile := ""
         this.Gui := ""
         this.GuiMenu := ""
@@ -227,6 +226,8 @@ class MacroEditGui {
             IL_Add(ImageListID, "Images\Soft\WindowManage.png")   ;29 窗口管理
             IL_Add(ImageListID, "Images\Soft\KeyCheck.png")   ;30 按键检测
         }
+
+        WindowHotkeyManager.Register(this, MacroEditGui.Hotkeys, this.OnSoftKey.Bind(this), this._IsAlive.Bind(this))
 
         if (this.OwnerHwnd != "" && MySoftData.IsModalSubGui) {
             try {
@@ -564,6 +565,7 @@ class MacroEditGui {
     }
 
     OnGuiClose() {
+        WindowHotkeyManager.Unregister(this)
         if (this.OwnerHwnd != "" && MySoftData.IsModalSubGui) {
             try {
                 GuiFromHwnd(this.OwnerHwnd).Opt("-Disabled")
@@ -669,13 +671,18 @@ class MacroEditGui {
         }
     }
 
-    OnSoftKey(key, isDown) {
+    _IsAlive() {
         if (!IsObject(this.Gui))
-            return
+            return false
+        hwnd := this.Gui.Hwnd
+        if (!hwnd || !WinExist("ahk_id " hwnd))
+            return false
+        style := WinGetStyle(hwnd)
+        return !!(style & 0x10000000) && WinActive("ahk_id " hwnd)
+    }
 
-        style := WinGetStyle(this.Gui.Hwnd)
-        isVisible := (style & 0x10000000)  ; 0x10000000 = WS_VISIBLE
-        if (!isVisible || !isDown)
+    OnSoftKey(key, isDown) {
+        if (!isDown)
             return
 
         if (key == "f5")

--- a/Gui/MenuWheelGui.ahk
+++ b/Gui/MenuWheelGui.ahk
@@ -3,6 +3,8 @@
 #Include "..\Plugins\AHK-XAML\lib\XAML_Generator.ahk"
 
 class MenuWheelGui {
+    static Hotkeys := ["1", "2", "3", "4", "5", "6", "7", "8"]
+
     __new() {
         this.MenuIndex := 1
         this.Gui := ""
@@ -143,16 +145,9 @@ class MenuWheelGui {
     OnSoftKey(key, isDown) {
         if (!isDown || !this.isOpen)
             return
-        numberArr := ["1", "2", "3", "4", "5", "6", "7", "8"]
-        loop numberArr.Length {
-            if (key == numberArr[A_Index]) {
-                idx := Integer(key)
-                if (idx >= 1 && idx <= 8 && IsObject(this.ui)) {
-                    this.DoSelect(idx, "")
-                }
-                return
-            }
-        }
+        idx := Integer(key)
+        if (idx >= 1 && idx <= MenuWheelGui.Hotkeys.Length && IsObject(this.ui))
+            this.DoSelect(idx, "")
     }
 
     Close() {
@@ -345,7 +340,6 @@ class MenuWheelGui {
         this.ui := XAMLHost(win.ToString(), "", 0)
         this.closed := false
         this.swipeTriggered := false
-        this.Gui := { Hwnd: this.ui.wpfHwnd }
         this.isOpen := true
 
         Loop itemCount {
@@ -380,6 +374,13 @@ class MenuWheelGui {
             if (this.HasProp("ui") && IsObject(this.ui))
                 this.ui.Update("SwipeLine", "Visibility", "Collapsed")
         }
+        this._aliveHwnd := this.ui.wpfHwnd
+        this.Gui := { Hwnd: this.ui.wpfHwnd }
+        WindowHotkeyManager.Register(this, MenuWheelGui.Hotkeys, this.OnSoftKey.Bind(this), this._IsAlive.Bind(this))
+    }
+
+    _IsAlive() {
+        return WinExist("ahk_id " this._aliveHwnd)
     }
 
     static _H(menu, idx) {
@@ -466,6 +467,7 @@ class MenuWheelGui {
     }
 
     _Cleanup() {
+        WindowHotkeyManager.Unregister(this)
         this.isOpen := false
         this._CancelPendingSelect()
         if (IsObject(this.swipe))
@@ -479,9 +481,6 @@ class MenuWheelGui {
         }
         this.ui := ""
         this.Gui := ""
-        BindSoftHotKey()
-        BindMenuHotKey()
-        BindTabHotKey()
     }
 
     DoCancel() {

--- a/Main/BindUtil.ahk
+++ b/Main/BindUtil.ahk
@@ -27,7 +27,10 @@ BindShortcut(triggerInfo, action) {
     }
     else {
         isCombo := IsComboKey(triggerInfo)
-        if (isCombo) {
+        mapKey := StrLower(Trim(triggerInfo, "~"))
+        if (WindowHotkeyManager.IsManaged(mapKey)) {
+            key := "$~" mapKey
+        } else if (isCombo) {
             key := triggerInfo
         }
         else {
@@ -281,6 +284,8 @@ BindMenuHotKey() {
             continue
 
         oriKey := FoldInfo.TKArr[index]
+        if (WindowHotkeyManager.IsManaged(StrLower(oriKey)))
+            continue
         isCombo := IsComboKey(oriKey)
         if (isCombo) {
             key := oriKey
@@ -341,6 +346,8 @@ BindTabHotKey() {
                 continue
 
             rawKey := tableItem.TKArr[index]
+            if (WindowHotkeyManager.IsManaged(StrLower(rawKey)))
+                continue
             isCombo := IsComboKey(rawKey)
             if (isCombo) {
                 key := rawKey
@@ -493,43 +500,18 @@ BindSoftHotKey() {
         isCombo := IsComboKey(mapKey)
 
         if (WindowHotkeyManager.IsManaged(mapKey)) {
-            key := isCombo ? mapKey : ("$*" mapKey)
-            actionDown := OnBindKeyDown.Bind(value)
-            actionUp := OnBindKeyUp.Bind(value)
-            try {
-                Hotkey(key, actionDown, "On")
-                if (!isCombo)
-                    Hotkey(key " up", actionUp, "On")
-            }
-            catch as e {
-            }
-            continue
-        }
-
-        isMenuBtnHotKey := CheckIfMenuBtnHotKey(mapKey)
-        isOpenMenu := MySoftData.CurMenuWheelIndex != -1
-        IsOnlySoftHotkey := MySoftData.TriggerKeyMap[mapKey].IsOnlySoftHotkey()
-
-        if (isCombo) {
+            key := "$~" mapKey
+        } else if (isCombo) {
             key := value
         }
         else if (SubStr(value, 1, 1) == "~") {
             key := "$" value
         }
         else {
-            key := "$" value
+            key := "$*" value
         }
         actionDown := OnBindKeyDown.Bind(value)
         actionUp := OnBindKeyUp.Bind(value)
-
-        if (isMenuBtnHotKey && !isOpenMenu && IsOnlySoftHotkey) {
-            Hotkey(key, actionDown, "Off")
-            if (!isCombo)
-                Hotkey(key " up", actionUp, "Off")
-        }
-
-        if (isMenuBtnHotKey && !isOpenMenu)
-            continue
 
         try {
             Hotkey(key, actionDown, "On")

--- a/Main/DataClass.Ahk
+++ b/Main/DataClass.Ahk
@@ -291,9 +291,8 @@ class SoftData {
         this.VarListenHeight := 420
 
         this.TriggerKeyMap := Map()     ;所有的按键宏，包括软件自身的快捷键
-        this.SoftHotKeyArr := ["~WheelUp", "~WheelDown", "~LButton", "~Left", "~Right", "~Up", "~Down", "~Enter", "1",
-            "2", "3", "4", "5", "6", "7", "8", "~F5", "~F6", "~Delete", "~NumpadDot"]
-        ; this.SoftHotKeyArr := ["1", "2", "3", "4", "5", "6", "7", "8"]      ;测试时候启动
+        this.SoftHotKeyArr := ["~WheelUp", "~WheelDown", "~LButton", "~Left", "~Right", "~Up", "~Down", "~Enter", "~1",
+            "~2", "~3", "~4", "~5", "~6", "~7", "~8", "~F5", "~F6", "~Delete", "~NumpadDot"]
 
         this.SelectAreaAction := "" ;左键框选范围回调   显示框选范围       正常
         this.GetAreaAction := ""    ;左键框选范围回调   不显示框选范围      系统截图获取截图范围

--- a/Main/RMTUtil.ahk
+++ b/Main/RMTUtil.ahk
@@ -942,13 +942,6 @@ FormatIntegerWithCommas(num) {
     return RegExReplace(num, "(\d)(?=(\d{3})+$)", "$1,")
 }
 
-CheckIfMenuBtnHotKey(key) {
-    if (IsNumber(key)) {
-        return Integer(key) >= 1 && Integer(key) <= 8
-    }
-    return false
-}
-
 OpenMenuWheel(MenuIndex, isTog) {
     if (IsObject(MyMenuWheel) && MyMenuWheel.isOpen && MySoftData.CurMenuWheelIndex == MenuIndex) {
         if (isTog)
@@ -958,11 +951,6 @@ OpenMenuWheel(MenuIndex, isTog) {
 
     MySoftData.CurMenuWheelIndex := MenuIndex
     MyMenuWheel.ShowGui(MenuIndex)
-
-    ;重新绑定一下，让菜单按钮快捷键不会被输入
-    BindMenuHotKey()
-    BindTabHotKey()
-    BindSoftHotKey()
 }
 
 CloseMenuWheel() {

--- a/Main/TriggerKeyData.ahk
+++ b/Main/TriggerKeyData.ahk
@@ -110,12 +110,9 @@ class TriggerKeyData {
     }
 
     OnTriggerKeyDown() {
-        isMenuBtnHotKey := CheckIfMenuBtnHotKey(this.Key)
-        isOpenMenu := MySoftData.CurMenuWheelIndex != -1
         this.UpdataArr()
         this.HandleSoftHotKeyDown()
-        if (isMenuBtnHotKey && isOpenMenu)
-            return
+
         if (WindowHotkeyManager.IsManaged(this.Key) && WindowHotkeyManager.IsAnyWindowActive(this.Key))
             return
 
@@ -152,8 +149,10 @@ class TriggerKeyData {
     OnTriggerKeyUp() {
         this.UpdataArr()
         this.HandleSoftHotKeyUp()
+
         if (WindowHotkeyManager.IsManaged(this.Key) && WindowHotkeyManager.IsAnyWindowActive(this.Key))
             return
+
         for index, value in this.LoosenArr {
             value.Action()
         }
@@ -228,16 +227,8 @@ class TriggerKeyData {
             }
         }
 
-        isMenuBtnHotKey := CheckIfMenuBtnHotKey(this.Key)
-        if (isMenuBtnHotKey)
-            MyMenuWheel.OnSoftKey(this.Key, true)
-
-        if (WindowHotkeyManager.IsManaged(this.Key)) {
-            if (WindowHotkeyManager.HandleKey(this.Key, true))
-                return
-            SendLevel 1
-            Send("{Blind}{" this.Key "}")
-        }
+        if (WindowHotkeyManager.IsManaged(this.Key) && WindowHotkeyManager.HandleKey(this.Key, true))
+            return
     }
 
     HandleSoftHotKeyUp() {
@@ -258,12 +249,8 @@ class TriggerKeyData {
             MyColorPanel.OnEnterUp(this.Key)
         }
 
-        if (WindowHotkeyManager.IsManaged(this.Key)) {
-            if (WindowHotkeyManager.HandleKey(this.Key, false))
-                return
-            SendLevel 1
-            Send("{Blind}{" this.Key " up}")
-        }
+        if (WindowHotkeyManager.IsManaged(this.Key) && WindowHotkeyManager.HandleKey(this.Key, false))
+            return
     }
 }
 

--- a/Main/WindowHotkeyManager.ahk
+++ b/Main/WindowHotkeyManager.ahk
@@ -1,34 +1,34 @@
 #Requires AutoHotkey v2.0
 
-/**
- * 窗口热键管理器
- * 为特定窗口实例注册专属热键，窗口激活时拦截处理，失活时Send转发
- */
 class WindowHotkeyManager {
     static KeyHandlers := Map()
 
-    /**
-     * 注册窗口实例的热键
-     * @param instance 窗口实例（需有 Gui 属性或 GetWinHwnd 方法）
-     * @param hotkeys 热键数组，如 ["f5", "f6"]
-     * @param callback 回调函数 callback(key, isDown)
-     */
-    static Register(instance, hotkeys, callback) {
+    static Register(instance, hotkeys, callback, aliveCheck := "") {
         for key in hotkeys {
             key := StrLower(key)
-            if (!WindowHotkeyManager.KeyHandlers.Has(key))
+            isFirst := !WindowHotkeyManager.KeyHandlers.Has(key)
+            if (isFirst)
                 WindowHotkeyManager.KeyHandlers[key] := []
-            WindowHotkeyManager.KeyHandlers[key].Push({
-                instance: instance,
-                callback: callback
-            })
+            duplicate := false
+            for h in WindowHotkeyManager.KeyHandlers[key] {
+                if (h.instance == instance) {
+                    h.callback := callback
+                    h.aliveCheck := aliveCheck
+                    duplicate := true
+                    break
+                }
+            }
+            if (!duplicate)
+                WindowHotkeyManager.KeyHandlers[key].Push({
+                    instance: instance,
+                    callback: callback,
+                    aliveCheck: aliveCheck
+                })
         }
     }
 
-    /**
-     * 注销窗口实例的所有热键
-     */
     static Unregister(instance) {
+        keysToClean := []
         for key, handlers in WindowHotkeyManager.KeyHandlers {
             i := handlers.Length
             while (i > 0) {
@@ -37,28 +37,24 @@ class WindowHotkeyManager {
                 i--
             }
             if (handlers.Length == 0)
-                WindowHotkeyManager.KeyHandlers.Delete(key)
+                keysToClean.Push(key)
         }
+        for k in keysToClean
+            WindowHotkeyManager.KeyHandlers.Delete(k)
     }
 
-    /**
-     * 检查某个键是否被管理器管理
-     */
     static IsManaged(key) {
         return WindowHotkeyManager.KeyHandlers.Has(StrLower(key))
     }
 
-    /**
-     * 将按键分发给激活窗口的回调，返回是否被处理
-     */
     static HandleKey(key, isDown) {
         key := StrLower(key)
-        handlers := WindowHotkeyManager.KeyHandlers[key]
-        if (!handlers)
+        WindowHotkeyManager._CleanupDead(key)
+        if (!WindowHotkeyManager.KeyHandlers.Has(key))
             return false
+        handlers := WindowHotkeyManager.KeyHandlers[key]
         for h in handlers {
-            hwnd := WindowHotkeyManager.GetInstanceHwnd(h.instance)
-            if (hwnd && WinActive("ahk_id " hwnd)) {
+            if (WindowHotkeyManager._IsActive(h)) {
                 h.callback.Call(key, isDown)
                 return true
             }
@@ -66,26 +62,60 @@ class WindowHotkeyManager {
         return false
     }
 
-    /**
-     * 检查某个键是否有激活的窗口
-     */
     static IsAnyWindowActive(key) {
         key := StrLower(key)
-        handlers := WindowHotkeyManager.KeyHandlers[key]
-        if (!handlers)
+        WindowHotkeyManager._CleanupDead(key)
+        if (!WindowHotkeyManager.KeyHandlers.Has(key))
             return false
+        handlers := WindowHotkeyManager.KeyHandlers[key]
         for h in handlers {
-            hwnd := WindowHotkeyManager.GetInstanceHwnd(h.instance)
-            if (hwnd && WinActive("ahk_id " hwnd))
+            if (WindowHotkeyManager._IsActive(h))
                 return true
         }
         return false
     }
 
-    /**
-     * 获取实例的窗口句柄
-     * 优先使用 Gui.Hwnd，其次调用 GetWinHwnd()
-     */
+    static _IsActive(h) {
+        if (h.aliveCheck != "" && IsObject(h.aliveCheck)) {
+            try
+                return h.aliveCheck.Call()
+            catch
+                return false
+        }
+        hwnd := WindowHotkeyManager.GetInstanceHwnd(h.instance)
+        return !!(hwnd && WinActive("ahk_id " hwnd))
+    }
+
+    static _CleanupDead(key) {
+        if (!WindowHotkeyManager.KeyHandlers.Has(key))
+            return
+        handlers := WindowHotkeyManager.KeyHandlers[key]
+        i := handlers.Length
+        while (i > 0) {
+            h := handlers[i]
+            isAlive := true
+            hwnd := WindowHotkeyManager.GetInstanceHwnd(h.instance)
+            if (hwnd) {
+                if (!WinExist("ahk_id " hwnd))
+                    isAlive := false
+            } else {
+                if (h.aliveCheck != "" && IsObject(h.aliveCheck)) {
+                    try
+                        isAlive := h.aliveCheck.Call()
+                    catch
+                        isAlive := false
+                } else {
+                    isAlive := false
+                }
+            }
+            if (!isAlive)
+                handlers.RemoveAt(i)
+            i--
+        }
+        if (handlers.Length == 0)
+            WindowHotkeyManager.KeyHandlers.Delete(key)
+    }
+
     static GetInstanceHwnd(instance) {
         try {
             if (IsObject(instance.Gui))


### PR DESCRIPTION
1.  使用WindowHotkeyManager统一管理窗口热键，替代原有的手动绑定解绑逻辑
2.  移除CheckIfMenuBtnHotKey函数和旧的绑定调用
3.  优化菜单快捷键和软件热键的处理，避免重复绑定
4.  新增窗口存活检测逻辑，自动清理无效的热键注册