### PR TITLE
build: 调整图标资源加载与打包逻辑

### DIFF
--- a/Main/RMTUtil.ahk
+++ b/Main/RMTUtil.ahk
@@ -255,24 +255,6 @@ InitFilePath() {
         DirCreate(A_WorkingDir "\Images\FreePaste")
     }
 
-    iconDir := A_WorkingDir "\Images\Soft"
-    static iconList := ["WeiXin.png", "ZhiFuBao.png", "rabit.ico", "IcoPause.ico",
-        "GreenColor.png", "RedColor.png", "YellowColor.png", "Target.png",
-        "Key.png", "Interval.png", "Search.png", "SearchPro.png",
-        "Move.png", "MovePro.png", "Output.png", "Run.png",
-        "Var.png", "Extract.png", "Operation.png", "If.png",
-        "rabit.png", "Sub.png", "Mouse.png", "True.png",
-        "False.png", "Loop.png", "LoopBody.png", "LoopCount.png",
-        "Condition.png", "IfPro.png", "Arr.png", "Input.png",
-        "TextOps.png", "FileIO.png", "Control.png", "WindowManage.png",
-        "KeyCheck.png"]
-
-    for iconName in iconList {
-        dstPath := iconDir "\" iconName
-        if (!FileExist(dstPath))
-            FileInstall("Images\Soft\" iconName, dstPath, 1)
-    }
-
     global VBSPath := A_WorkingDir "\MinTool\PlayAudio.vbs"
     global StartTipAudio := A_WorkingDir "\Audio\Start.wav"
     global EndTipAudio := A_WorkingDir "\Audio\End.wav"

--- a/PackRMT.ps1
+++ b/PackRMT.ps1
@@ -249,6 +249,13 @@ function New-Release {
         }
         Copy-Item -Path "$PSScriptRoot\Lang" -Destination "$releaseDir\Lang" -Force -Recurse -ErrorAction SilentlyContinue
 
+        # 复制 Images 目录
+        Write-Log "复制 Images 目录..." "Gray"
+        if (Test-Path "$releaseDir\Images") {
+            Remove-Item "$releaseDir\Images" -Recurse -Force
+        }
+        Copy-Item -Path "$PSScriptRoot\Images" -Destination "$releaseDir\Images" -Force -Recurse -ErrorAction SilentlyContinue
+
         # 复制帮助文档（index.html）
         $helpSrc = Join-Path $PSScriptRoot "index.html"
         if (Test-Path $helpSrc) {
@@ -292,6 +299,13 @@ function New-Release {
             Remove-Item "$releaseDir\Lang" -Recurse -Force
         }
         Copy-Item -Path "$PSScriptRoot\Lang" -Destination "$releaseDir\Lang" -Force -Recurse -ErrorAction SilentlyContinue
+
+        # 复制 Images 目录
+        Write-Log "复制 Images 目录..." "Gray"
+        if (Test-Path "$releaseDir\Images") {
+            Remove-Item "$releaseDir\Images" -Recurse -Force
+        }
+        Copy-Item -Path "$PSScriptRoot\Images" -Destination "$releaseDir\Images" -Force -Recurse -ErrorAction SilentlyContinue
 
         # 复制帮助文档（index.html）
         $helpSrc = Join-Path $PSScriptRoot "index.html"

--- a/Plugins/AHK-XAML/lib/XAML_GUI.ahk
+++ b/Plugins/AHK-XAML/lib/XAML_GUI.ahk
@@ -402,9 +402,10 @@ class XAML_GUI {
         this.host.Update("Window", "DWM", "2,1")
         this.host.Update("Window", "Title", this.title)
 
-        hIcon := LoadPicture("shell32.dll", "Icon26", &ImageType := 1)
+        iconPath := A_WorkingDir "\Images\Soft\rabit.ico"
+        hIcon := LoadPicture(iconPath)
         this.host.Update("Window", "Icon", "HICON:" hIcon)
-        TraySetIcon("shell32.dll", 26)
+        TraySetIcon(iconPath)
 
         this.host.Update("AppTitle", "Text", this.title)
 


### PR DESCRIPTION
1. 替换内置shell32.dll图标为自定义rabit.ico图标
2. 移除自动复制内置图标文件的初始化逻辑
3. 打包脚本新增Images目录复制步骤