### PR TITLE
feat(轮盘): 增加轮盘大小参数/适配多屏/增加关闭按钮

### DIFF
--- a/Gui/MenuWheelGlobalSettingGui.ahk
+++ b/Gui/MenuWheelGlobalSettingGui.ahk
@@ -30,6 +30,7 @@ class MenuWheelGlobalSettingGui {
         this._fixedPos := false
         this._selectMode := 1
         this._showTooltip := true
+        this._wheelScale := 100
         this._currentTheme := "Default"
     }
 
@@ -51,7 +52,7 @@ class MenuWheelGlobalSettingGui {
         this.closed := false
 
         title := GetLang("轮盘选项")
-        this.app := XAML_GUI(title, { Sidebar: false, BurgerMenu: false, AppIcon: false, Width: 420, Height: 400 })
+        this.app := XAML_GUI(title, { Sidebar: false, BurgerMenu: false, AppIcon: false, Width: 420, Height: 440 })
         this.app.tabs.Visibility("Collapsed")
 
         this.LoadThemesFromIni()
@@ -66,12 +67,14 @@ class MenuWheelGlobalSettingGui {
         this.ui.Track("FixedPosCon")
         this.ui.Track("SelectModeCon")
         this.ui.Track("ShowTooltipCon")
+        this.ui.Track("WheelScaleCon")
 
         this.ui.OnEvent("FixedPosCon", "Checked", ObjBindMethod(this, "OnFixedPosChanged"))
         this.ui.OnEvent("FixedPosCon", "Unchecked", ObjBindMethod(this, "OnFixedPosChanged"))
         this.ui.OnEvent("SelectModeCon", "SelectionChanged", ObjBindMethod(this, "OnSelectModeChanged"))
         this.ui.OnEvent("ShowTooltipCon", "Checked", ObjBindMethod(this, "OnShowTooltipChanged"))
         this.ui.OnEvent("ShowTooltipCon", "Unchecked", ObjBindMethod(this, "OnShowTooltipChanged"))
+        this.ui.OnEvent("WheelScaleCon", "ValueChanged", ObjBindMethod(this, "OnWheelScaleChanged"))
 
         this.ui.OnEvent("BtnRevert", "Click", ObjBindMethod(this, "OnRevertClick"))
         this.ui.OnEvent("BtnConfirm", "Click", ObjBindMethod(this, "OnConfirmClick"))
@@ -168,6 +171,11 @@ class MenuWheelGlobalSettingGui {
         row3 := inner1.Add("StackPanel").Orientation("Horizontal").Margin("0,8,0,0")
         row3.Add("CheckBox").Name("ShowTooltipCon").Content(GetLang("显示扇区名称提示")).Foreground("{DynamicResource TextMain}").Margin("0,0,0,0")
 
+        row4 := inner1.Add("StackPanel").Orientation("Horizontal").Margin("0,10,0,0")
+        row4.Add("TextBlock").Text(GetLang("轮盘大小")).Foreground("{DynamicResource TextSub}").FontSize(11).VerticalAlignment("Center").Width(70)
+        scaleSlider := row4.Add("Slider").Name("WheelScaleCon").Width(160).Height(28).Margin("8,0,8,0").Minimum(50).Maximum(200).Value(100).IsSnapToTickEnabled("True").TickFrequency("10")
+        scaleValText := row4.Add("TextBlock").Name("WheelScaleValText").Foreground("{DynamicResource TextMain}").FontSize(12).VerticalAlignment("Center").Width(40)
+
         group3 := panel.Add("GroupBox").Header(GetLang("主题预设")).Margin("0,16,0,0")
         inner3 := group3.Add("StackPanel").Margin("14, 10")
 
@@ -194,6 +202,7 @@ class MenuWheelGlobalSettingGui {
         this._fixedPos := !!MySoftData.FixedMenuWheel
         this._selectMode := MySoftData.MenuWheelSelectMode
         this._showTooltip := !!MySoftData.MenuWheelShowTooltip
+        this._wheelScale := MySoftData.MenuWheelScale
 
         iniPath := A_WorkingDir "\Setting\MainSettings.ini"
         savedTheme := IniRead(iniPath, "MenuWheel", "CurrentTheme", "Default")
@@ -210,6 +219,8 @@ class MenuWheelGlobalSettingGui {
         this.ui.Update("FixedPosCon", "IsChecked", this._fixedPos ? "True" : "False")
         this.ui.Update("SelectModeCon", "SelectedIndex", String(this._selectMode - 1))
         this.ui.Update("ShowTooltipCon", "IsChecked", this._showTooltip ? "True" : "False")
+        this.ui.Update("WheelScaleCon", "Value", String(this._wheelScale))
+        this.ui.Update("WheelScaleValText", "Text", this._wheelScale "%")
 
         themeIdx := 0
         idx := 0
@@ -235,6 +246,12 @@ class MenuWheelGlobalSettingGui {
 
     OnShowTooltipChanged(state, ctrl, event) {
         this._showTooltip := (event == "Checked")
+    }
+
+    OnWheelScaleChanged(state, ctrl, event) {
+        valStr := state.Has("WheelScaleCon") ? state["WheelScaleCon"] : ""
+        this._wheelScale := Integer(valStr)
+        this.ui.Update("WheelScaleValText", "Text", this._wheelScale "%")
     }
 
     OnThemeSelectionChanged(state, ctrl, event) {
@@ -276,12 +293,15 @@ class MenuWheelGlobalSettingGui {
         this.ui.Update("FixedPosCon", "IsChecked", "False")
         this.ui.Update("SelectModeCon", "SelectedIndex", "0")
         this.ui.Update("ShowTooltipCon", "IsChecked", "True")
+        this.ui.Update("WheelScaleCon", "Value", "100")
+        this.ui.Update("WheelScaleValText", "Text", "100%")
         this.ui.Update("ThemeCombo", "SelectedIndex", "0")
         this.UpdateThemePreview(defaultTheme)
 
         this._fixedPos := false
         this._selectMode := 1
         this._showTooltip := true
+        this._wheelScale := 100
         this._currentTheme := "Default"
     }
 
@@ -306,12 +326,14 @@ class MenuWheelGlobalSettingGui {
         MySoftData.FixedMenuWheel := this._fixedPos
         MySoftData.MenuWheelSelectMode := this._selectMode
         MySoftData.MenuWheelShowTooltip := this._showTooltip
+        MySoftData.MenuWheelScale := this._wheelScale
 
         global IniFile, IniSection
         iniPath := A_WorkingDir "\Setting\MainSettings.ini"
         IniWrite(MySoftData.FixedMenuWheel, IniFile, IniSection, "FixedMenuWheel")
         IniWrite(MySoftData.MenuWheelSelectMode, IniFile, IniSection, "MenuWheelSelectMode")
         IniWrite(MySoftData.MenuWheelShowTooltip, IniFile, IniSection, "MenuWheelShowTooltip")
+        IniWrite(MySoftData.MenuWheelScale, IniFile, IniSection, "MenuWheelScale")
 
         IniWrite(this._currentTheme, iniPath, "MenuWheel", "CurrentTheme")
         for name in MenuWheelGlobalSettingGui.ColorNames

--- a/Gui/MenuWheelGui.ahk
+++ b/Gui/MenuWheelGui.ahk
@@ -73,19 +73,30 @@ class MenuWheelGui {
             })
         }
 
+        CoordMode("Mouse", "Screen")
+        MouseGetPos(&mx, &my)
         if (MySoftData.FixedMenuWheel) {
-            mx := Round(A_ScreenWidth * 0.5)
-            my := Round(A_ScreenHeight * 0.70)
-        } else {
-            CoordMode("Mouse", "Screen")
-            MouseGetPos(&mx, &my)
+            pt := Buffer(8, 0)
+            NumPut("Int", mx, pt, 0)
+            NumPut("Int", my, pt, 4)
+            hwndMon := DllCall("user32\MonitorFromPoint", "Ptr", pt, "UInt", 2, "Ptr")
+            monInfo := Buffer(40, 0)
+            NumPut("UInt", 40, monInfo, 0)
+            DllCall("user32\GetMonitorInfo", "Ptr", hwndMon, "Ptr", monInfo)
+            monLeft := NumGet(monInfo, 4, "Int")
+            monTop := NumGet(monInfo, 8, "Int")
+            monRight := NumGet(monInfo, 12, "Int")
+            monBottom := NumGet(monInfo, 16, "Int")
+            mx := Round((monLeft + monRight) * 0.5)
+            my := Round((monTop + monBottom) * 0.70)
         }
 
+        wheelScale := Max(Min(MySoftData.MenuWheelScale, 200), 30) / 100.0
         this._BuildAndShow(items, mx, my, {
-            Radius: 150,
-            InnerRadius: 60,
-            IconSize: 50,
-            FontSize: 11,
+            Radius: Round(150 * wheelScale),
+            InnerRadius: Round(60 * wheelScale),
+            IconSize: Round(50 * wheelScale),
+            FontSize: Max(Round(11 * wheelScale), 8),
             NormalFill: modNormalFill,
             NormalStroke: modNormalStroke,
             NormalText: "#CC333333",
@@ -167,8 +178,21 @@ class MenuWheelGui {
         this.labelPosRatio := labelPosRatio
         this.centerPosRatio := centerPosRatio
 
-        dpiScale := A_ScreenDPI / 96.0
-        this.dpiScale := dpiScale
+        finalX := x
+        finalY := y
+        if (finalX == "" or finalY == "") {
+            CoordMode("Mouse", "Screen")
+            MouseGetPos(&mx, &my)
+            finalX := mx
+            finalY := my
+        }
+        ptDpi := Buffer(8, 0)
+        NumPut("Int", finalX, ptDpi, 0)
+        NumPut("Int", finalY, ptDpi, 4)
+        hwndMon := DllCall("user32\MonitorFromPoint", "Ptr", ptDpi, "UInt", 2, "Ptr")
+        dpiX := 0, dpiY := 0
+        DllCall("shcore\GetDpiForMonitor", "Ptr", hwndMon, "Int", 0, "UInt*", &dpiX, "UInt*", &dpiY)
+        this.dpiScale := (dpiX > 0) ? (dpiX / 96.0) : (A_ScreenDPI / 96.0)
 
         itemCount := items.Length
         if (itemCount < 1)
@@ -188,14 +212,6 @@ class MenuWheelGui {
         winH := (radius + pad) * 2
         this.winSize := winW
 
-        finalX := x
-        finalY := y
-        if (finalX == "" or finalY == "") {
-            CoordMode("Mouse", "Screen")
-            MouseGetPos(&mx, &my)
-            finalX := mx
-            finalY := my
-        }
         winLeft := finalX / this.dpiScale - cx
         winTop := finalY / this.dpiScale - cy
 
@@ -250,6 +266,16 @@ class MenuWheelGui {
             wedge := canvas.Add("Path").Name("Wedge_" idx)
             wedge.Data(pathData).Fill(normalFill).Stroke(normalStroke).StrokeThickness(normalThickness).Cursor("Hand")
         }
+
+        centerCircle := canvas.Add("Ellipse").Name("CenterCircle")
+        centerCircle.Width(innerR * 2).Height(innerR * 2)
+        centerCircle.Canvas_Left(cx - innerR).Canvas_Top(cy - innerR)
+        centerCircle.Fill(normalFill).Stroke(normalStroke).StrokeThickness(normalThickness).Cursor("Hand")
+
+        closeIcon := canvas.Add("TextBlock").Name("CloseIcon")
+        closeIcon.Text("✕").FontSize(Round(fontSize * 1.4)).Foreground(this.normalText).FontWeight("SemiBold")
+        closeIcon.TextAlignment("Center").IsHitTestVisible("False")
+        closeIcon.Canvas_Left(cx - fontSize * 0.6).Canvas_Top(cy - Round(fontSize * 0.7))
 
         Loop itemCount {
             idx := A_Index
@@ -323,6 +349,10 @@ class MenuWheelGui {
             this.ui.OnEvent("Wedge_" idx, "MouseLeave", h.Leave)
             this.ui.OnEvent("IconBg_" idx, "MouseLeave", h.Leave)
         }
+
+        this.ui.OnEvent("CenterCircle", "PreviewMouseLeftButtonDown", (*) => this.DoCancel())
+        this.ui.OnEvent("CenterCircle", "MouseMove", (*) => this.DoCenterHover())
+        this.ui.OnEvent("CenterCircle", "MouseLeave", (*) => this.DoCenterLeave())
 
         this.ui.OnEvent("RootCanvas", "MouseMove", (*) => this.DoCanvasMove())
 
@@ -420,6 +450,31 @@ class MenuWheelGui {
             this._CancelPendingSelect()
             this.sectors[prevIdx].OnLeave(this)
             this.hoveredIdx := 0
+        }
+        ToolTip()
+    }
+
+    DoCenterHover(*) {
+        if (!this.isOpen || this.closed)
+            return
+        if (this.HasProp("ui") && IsObject(this.ui)) {
+            this.ui.Update("CenterCircle", "Fill", this.hoverFill)
+            this.ui.Update("CenterCircle", "Stroke", this.hoverStroke)
+            this.ui.Update("CenterCircle", "StrokeThickness", String(this.hoverThickness))
+            this.ui.Update("CloseIcon", "Foreground", this.hoverText)
+        }
+        if (this.showTooltip)
+            ToolTip(GetLang("关闭"))
+    }
+
+    DoCenterLeave(*) {
+        if (!this.isOpen || this.closed)
+            return
+        if (this.HasProp("ui") && IsObject(this.ui)) {
+            this.ui.Update("CenterCircle", "Fill", this.normalFill)
+            this.ui.Update("CenterCircle", "Stroke", this.normalStroke)
+            this.ui.Update("CenterCircle", "StrokeThickness", String(this.normalThickness))
+            this.ui.Update("CloseIcon", "Foreground", this.normalText)
         }
         ToolTip()
     }

--- a/Main/AssetUtil.ahk
+++ b/Main/AssetUtil.ahk
@@ -448,6 +448,7 @@ LoadMainSetting() {
     MySoftData.FixedMenuWheel := IniRead(IniFile, IniSection, "FixedMenuWheel", false)
     MySoftData.MenuWheelSelectMode := IniRead(IniFile, IniSection, "MenuWheelSelectMode", 1)
     MySoftData.MenuWheelShowTooltip := IniRead(IniFile, IniSection, "MenuWheelShowTooltip", true)
+    MySoftData.MenuWheelScale := IniRead(IniFile, IniSection, "MenuWheelScale", 100)
     MySoftData.XAMLTheme := IniRead(IniFile, IniSection, "XAMLTheme", "RMT Light")
     EnsureXAMLThemesIni()
     MySoftData.IsModalSubGui := IniRead(IniFile, IniSection, "IsModalSubGui", true)

--- a/Main/DataClass.Ahk
+++ b/Main/DataClass.Ahk
@@ -203,6 +203,7 @@ class SoftData {
         this.IsAdminStart := false        ;管理员启动
         this.ShowSplitLine := false     ;显示分割线
         this.FixedMenuWheel := false    ;固定菜单轮
+        this.MenuWheelScale := 100      ;轮盘大小(百分比)
         this.XAMLTheme := "RMT Light"   ;XAML界面主题
         this.NoVariableTip := false     ;无变量提醒
         this.ScreenShotType := 3        ;截图类型


### PR DESCRIPTION
1. 新增MenuWheelScale配置项支持自定义轮盘缩放比例，范围30%-200%
2. 为固定模式轮盘添加多显示器适配，居中显示在当前鼠标所在屏幕
3. 新增轮盘中心圆形区域和关闭按钮，点击可关闭菜单轮盘
4. 完善全局设置界面，添加轮盘大小调节滑块
5. 修复原有的DPI适配逻辑，使用显示器实际DPI进行缩放