### PR TITLE
fix(WindowManageGui): 恢复搜索框值的初始化逻辑

### DIFF
--- a/Gui/WindowManageGui.ahk
+++ b/Gui/WindowManageGui.ahk
@@ -46,6 +46,7 @@ class WindowManageGui {
         this.Data := GetMacroCMDData(this.SerialStr)
 
         this.ActionTypeCon.Text := this.Data.ActionType
+        this.SearchValueCon.Value := this.Data.SearchValue
         SetDLConValue(this.PosXCon, DLVariableArr, this.Data.PosX)
         SetDLConValue(this.PosYCon, DLVariableArr, this.Data.PosY)
         SetDLConValue(this.WidthCon, DLVariableArr, this.Data.Width)


### PR DESCRIPTION
补全了窗体管理GUI中搜索输入框的初始值赋值代码，确保界面加载时正确显示保存的搜索配置