### PR TITLE
fix: 统一RMT指令格式并调整解析逻辑

### DIFF
--- a/Gui/RMTCMDGui.ahk
+++ b/Gui/RMTCMDGui.ahk
@@ -61,22 +61,17 @@ class RMTCMDGui {
     }
 
     Init(cmd) {
-        ; CMD格式: RMT指令_类别_指令_序号（新）或 RMT指令_指令_序号（旧兼容）
-        cmdArr := cmd != "" ? StrSplit(cmd, "_") : []
         ; 新格式: RMT指令_类别_指令 或 RMT指令_类别_指令_序号
-        ; 旧格式: RMT指令_指令
+        cmdArr := cmd != "" ? StrSplit(cmd, "_") : []
         if (cmdArr.Length >= 4) {
-            ; 新格式
             cmdCategory := cmdArr[2]
             cmdStr := cmdArr[3]
             menuDLIndex := cmdStr == GetLang("显示菜单") && cmdArr.Length >= 5 ? cmdArr[4] : 1
         } else if (cmdArr.Length >= 3) {
-            ; 旧格式：只有指令和序号，没有类别
-            cmdCategory := GetLang("全部")
-            cmdStr := cmdArr[2]
-            menuDLIndex := cmdStr == GetLang("显示菜单") && cmdArr.Length >= 4 ? cmdArr[3] : 1
+            cmdCategory := cmdArr[2]
+            cmdStr := cmdArr[3]
+            menuDLIndex := 1
         } else {
-            ; 无效格式，使用默认值
             cmdCategory := GetLang("全部")
             cmdStr := GetLang("截图")
             menuDLIndex := 1

--- a/Main/RMTUtil.ahk
+++ b/Main/RMTUtil.ahk
@@ -564,8 +564,9 @@ ToolTipTimer() {
 }
 
 ExcuteRMTCMDAction(Cmd) {
+    ; 新格式: RMT指令⫶类别⫶指令 → paramArr[1]=RMT指令, paramArr[2]=类别, paramArr[3]=指令
     paramArr := StrSplit(Cmd, "⫶")
-    switch paramArr[2] {
+    switch paramArr[3] {
         case "截图":
             OnToolScreenShot()
         case "截图提取文本":

--- a/Main/Util/InputUtil.ahk
+++ b/Main/Util/InputUtil.ahk
@@ -2,7 +2,7 @@
 
 InputPopUp(Data, tableItem, index) {
     if (Data.PauseType == "暂停所有宏")
-        MyExcuteRMTCMDAction("RMT指令_暂停所有宏")
+        MyExcuteRMTCMDAction("RMT指令_宏控制_暂停所有宏")
 
     isHide := false
     InputBoxSureAction(Content) {
@@ -23,12 +23,12 @@ InputPopUp(Data, tableItem, index) {
         Sleep(200)
     }
     if (Data.PauseType == "暂停所有宏")
-        MyExcuteRMTCMDAction("RMT指令_恢复所有宏")
+        MyExcuteRMTCMDAction("RMT指令_宏控制_恢复所有宏")
 }
 
 InputStateValue(Data, tableItem, index) {
     if (Data.PauseType == "暂停所有宏")
-        MyExcuteRMTCMDAction("RMT指令_暂停所有宏")
+        MyExcuteRMTCMDAction("RMT指令_宏控制_暂停所有宏")
 
     isHide := false
     InputBoxTrueAction() {
@@ -48,12 +48,12 @@ InputStateValue(Data, tableItem, index) {
         Sleep(200)
     }
     if (Data.PauseType == "暂停所有宏")
-        MyExcuteRMTCMDAction("RMT指令_恢复所有宏")
+        MyExcuteRMTCMDAction("RMT指令_宏控制_恢复所有宏")
 }
 
 InputContinue(Data, tableItem, index) {
     if (Data.PauseType == "暂停所有宏")
-        MyExcuteRMTCMDAction("RMT指令_暂停所有宏")
+        MyExcuteRMTCMDAction("RMT指令_宏控制_暂停所有宏")
 
     isHide := false
     InputBtnHideAciton() {
@@ -65,19 +65,19 @@ InputContinue(Data, tableItem, index) {
         Sleep(200)
     }
     if (Data.PauseType == "暂停所有宏")
-        MyExcuteRMTCMDAction("RMT指令_恢复所有宏")
+        MyExcuteRMTCMDAction("RMT指令_宏控制_恢复所有宏")
 }
 
 InputContinueAndCencel(Data, tableItem, index) {
     if (Data.PauseType == "暂停所有宏")
-        MyExcuteRMTCMDAction("RMT指令_暂停所有宏")
+        MyExcuteRMTCMDAction("RMT指令_宏控制_暂停所有宏")
 
     isHide := false
     InputBtnCancelAciton() {
         if (Data.CancelType == "终止当前宏")
             MyStopMacro(tableItem.Index, index)
         if (Data.CancelType == "终止所有宏")
-            MyExcuteRMTCMDAction("RMT指令_终止所有宏")
+            MyExcuteRMTCMDAction("RMT指令_宏控制_终止所有宏")
     }
     InputBtnHideAciton() {
         isHide := true
@@ -89,5 +89,5 @@ InputContinueAndCencel(Data, tableItem, index) {
         Sleep(200)
     }
     if (Data.PauseType == "暂停所有宏")
-        MyExcuteRMTCMDAction("RMT指令_恢复所有宏")
+        MyExcuteRMTCMDAction("RMT指令_宏控制_恢复所有宏")
 }

--- a/Main/Util/MacroUtil.ahk
+++ b/Main/Util/MacroUtil.ahk
@@ -967,8 +967,9 @@ OnMouseMove(tableItem, cmd, index) {
 }
 
 OnRMTCMD(tableItem, cmd, index) {
+    ; 新格式: RMT指令_类别_指令 → paramArr[1]=RMT指令, paramArr[2]=类别, paramArr[3]=指令
     paramArr := StrSplit(cmd, "_")
-    cmdStr := paramArr[2]
+    cmdStr := paramArr[3]
     if (cmdStr == "启用键鼠") {
         BlockInput false
     }


### PR DESCRIPTION
1. 调整RMT指令分隔符为⫶替代下划线，新增格式说明注释
2. 重构RMTCMD解析逻辑，移除旧格式兼容代码
3. 更新所有调用处的指令字符串格式，补充宏控制分类