### PR TITLE
refactor: 重构热键管理系统，替换原有WindowHotkeyManager

### DIFF
--- a/Gui/CMDTipGui.ahk
+++ b/Gui/CMDTipGui.ahk
@@ -8,6 +8,7 @@ class CMDTipGui {
         this.isLoadParams := false
         this.ShowCount := 0
         this.ContentCon := ""
+        this._wheelCb := ""
     }
 
     ShowGui(CMDStr) {
@@ -28,6 +29,13 @@ class CMDTipGui {
         }
 
         this.AddCMD(CMDStr)
+
+        ; 订阅滚轮热键（仅首次或窗口重建时）
+        if (!this._wheelCb) {
+            this._wheelCb := ObjBindMethod(this, "_OnWheel")
+            WinHotkey.SubscribeMouse("WheelUp", this._wheelCb)
+            WinHotkey.SubscribeMouse("WheelDown", this._wheelCb)
+        }
     }
 
     LoadParams() {
@@ -74,12 +82,24 @@ class CMDTipGui {
         SendMessage(0xB6, 0, 10000, this.ContentCon)
     }
 
-    Clear() {
+    Hide() {
         if (this.Gui == "")
             return
 
         this.ShowCount := 0
         this.ContentCon.Value := ""
+        this.Gui.Hide()
+
+        ; 取消订阅滚轮热键
+        if (this._wheelCb) {
+            WinHotkey.UnsubscribeMouse("WheelUp", this._wheelCb)
+            WinHotkey.UnsubscribeMouse("WheelDown", this._wheelCb)
+            this._wheelCb := ""
+        }
+    }
+
+    _OnWheel(key, *) {
+        this.OnScrollWheel(key)
     }
 
     OnToggleMacroWorkState() {

--- a/Gui/ColorPanelGui.ahk
+++ b/Gui/ColorPanelGui.ahk
@@ -18,6 +18,7 @@ class ColorPanelGui {
         this.GuiHeight := 150
 
         this.SureAction := ""
+        this._hkIds := []
     }
 
     ShowGui() {
@@ -27,6 +28,9 @@ class ColorPanelGui {
         else {
             this.AddGui()
         }
+        ; 注册 Enter 热键（颜色面板活动期间有效）
+        if (this._hkIds.Length == 0)
+            this._hkIds := WinHotkey.Register(["Enter"], ObjBindMethod(this, "_OnEnter"))
         this.RefreshCoord()
         this.RefreshMapImage()
     }
@@ -92,8 +96,7 @@ class ColorPanelGui {
         if (!isVisible)
             return
 
-        this.Gui.Hide()
-        MyTargetGui.Gui.Hide()
+        this._DoHide()
         if (this.SureAction == "")
             return
         action := this.SureAction
@@ -102,11 +105,22 @@ class ColorPanelGui {
     }
 
     OnClose(*) {
-        this.Gui.Hide()
-        MyTargetGui.Gui.Hide()
+        this._DoHide()
     }
 
-    OnEnterUp(*) {
+    _DoHide() {
+        if (this._hkIds.Length > 0) {
+            WinHotkey.UnregisterAll(this._hkIds)
+            MyTargetGui.HideGui()
+            this._hkIds := []
+        }
+        if (this.Gui != "")
+            this.Gui.Hide()
+        if (MyTargetGui.Gui != "")
+            MyTargetGui.Gui.Hide()
+    }
+
+    _OnEnter(key) {
         if (this.Gui == "")
             return
         style := WinGetStyle(this.Gui.Hwnd)
@@ -114,13 +128,12 @@ class ColorPanelGui {
         if (!isVisible)
             return
 
-        this.Gui.Hide()
-        MyTargetGui.Gui.Hide()
+        this._DoHide()
         if (this.SureAction == "")
             return
         action := this.SureAction
         colorStr := Format("{:06X}", this.ColorValue)
-        action(this.CoordX, this.CoordY,colorStr)
+        action(this.CoordX, this.CoordY, colorStr)
     }
 
     RefreshCoord() {

--- a/Gui/FreePasteGui.ahk
+++ b/Gui/FreePasteGui.ahk
@@ -1,10 +1,30 @@
 class FreePasteGui {
     __new() {
         this.GuiMap := Map()
+        this._wheelCb := ""
     }
 
     ShowGui() {
         this.AddGui()
+        ; 订阅滚轮热键（粘贴窗口活动期间有效）
+        if (!this._wheelCb) {
+            this._wheelCb := ObjBindMethod(this, "_OnWheel")
+            WinHotkey.SubscribeMouse("WheelUp", this._wheelCb)
+            WinHotkey.SubscribeMouse("WheelDown", this._wheelCb)
+        }
+    }
+
+    DestroyGui(gui) {
+        hwnd := gui.Hwnd
+        gui.Destroy()
+        if (this.GuiMap.Has(hwnd))
+            this.GuiMap.Delete(hwnd)
+        ; 所有窗口都销毁后取消订阅滚轮热键
+        if (this.GuiMap.Count == 0 && this._wheelCb) {
+            WinHotkey.UnsubscribeMouse("WheelUp", this._wheelCb)
+            WinHotkey.UnsubscribeMouse("WheelDown", this._wheelCb)
+            this._wheelCb := ""
+        }
     }
 
     AddGui() {
@@ -69,13 +89,17 @@ class FreePasteGui {
     }
 
     DoubleClick(gui, *) {
-        gui.Destroy()
+        this.DestroyGui(gui)
         gui := ""
     }
 
     ; 拖动函数
     GuiDrag(gui, *) {
         PostMessage(0xA1, 2, , , gui)
+    }
+
+    _OnWheel(key) {
+        this.OnScrollWheel(key)
     }
 
     OnScrollWheel(key) {

--- a/Gui/MacroEditGui.ahk
+++ b/Gui/MacroEditGui.ahk
@@ -241,7 +241,8 @@ class MacroEditGui {
             IL_Add(ImageListID, "Images\Soft\ScreenShot.png")
         }
 
-        WindowHotkeyManager.Register(this, MacroEditGui.Hotkeys, this.OnSoftKey.Bind(this), this._IsAlive.Bind(this))
+        ; 注册快捷键热键（窗口打开期间全局有效，关闭时注销）
+        this._hkIds := WinHotkey.Register(["F5", "F6", "Delete"], ObjBindMethod(this, "_OnHotkey"))
 
         if (this.OwnerHwnd != "" && MySoftData.IsModalSubGui) {
             try {
@@ -586,7 +587,8 @@ class MacroEditGui {
     }
 
     OnGuiClose() {
-        WindowHotkeyManager.Unregister(this)
+        if (this._hkIds.Length > 0)
+            WinHotkey.UnregisterAll(this._hkIds)
         if (this.OwnerHwnd != "" && MySoftData.IsModalSubGui) {
             try {
                 GuiFromHwnd(this.OwnerHwnd).Opt("-Disabled")
@@ -694,14 +696,13 @@ class MacroEditGui {
         }
     }
 
-    _IsAlive() {
-        if (!IsObject(this.Gui))
-            return false
-        hwnd := this.Gui.Hwnd
-        if (!hwnd || !WinExist("ahk_id " hwnd))
-            return false
-        style := WinGetStyle(hwnd)
-        return !!(style & 0x10000000) && WinActive("ahk_id " hwnd)
+    _OnHotkey(key) {
+        if (key == "F5")
+            this.RunMacro()
+        else if (key == "F6")
+            this.StepRun()
+        else if (key == "Delete")
+            this.DeleteCurrentRow()
     }
 
     OnSoftKey(key, isDown) {
@@ -829,7 +830,7 @@ class MacroEditGui {
                 MacroStr := GetLangMacro(macroStr, 2)
                 ResArr := StrSplit(MacroStr, "⭐", 2)
                 MacroStr := ResArr.Length > 1 ? ResArr[2] : MacroStr
-                MyCMDTipGui.Clear()
+                MyCMDTipGui.Hide()
                 OnTriggerSepcialItemMacro(MacroStr)
                 MsgBox(GetLang("调试运行结束"), "", "Owner" this.Gui.Hwnd)
             }
@@ -842,7 +843,7 @@ class MacroEditGui {
 
                 ; 阶段1: 定位（首次F6或终止后，查找⭐起点或第一项）
                 if (this.DebugItemID == 0) {
-                    MyCMDTipGui.Clear()
+                    MyCMDTipGui.Hide()
                     this.DebugItemID := this.FindDebugStartItem()
                     if (!this.DebugItemID) {
                         this.DebugItemID := this.MacroTreeViewCon.GetNext(0)

--- a/Gui/MenuWheelGui.ahk
+++ b/Gui/MenuWheelGui.ahk
@@ -338,9 +338,15 @@ class MenuWheelGui {
                 lbl.Text(sec.Name)
                 lbl.FontFamily("Segoe UI Variable Display, Segoe UI, sans-serif")
                 lbl.FontSize(fontSize).Foreground(this.normalText).FontWeight("SemiBold")
-                lbl.TextAlignment("Center")
-                lbl.TextTrimming("CharacterEllipsis")
-                lbl.Canvas_Left(lpx - 39).Canvas_Top(lpy - 8).Width(78).IsHitTestVisible("False")
+                lbl.TextAlignment("Center").TextTrimming("CharacterEllipsis")
+                lbl.Width(Round(78 * this.dpiScale)).Canvas_Left(lpx - Round(39 * this.dpiScale)).Canvas_Top(lpy - 8).IsHitTestVisible("False")
+
+                ; 运行状态色点（默认隐藏，放在文本下方居中）
+                dotSize := Round(8 * this.dpiScale)
+                stateDot := canvas.Add("Ellipse").Name("StateDot_" idx)
+                stateDot.Width(dotSize).Height(dotSize)
+                stateDot.Canvas_Left(lpx - Round(dotSize / 2)).Canvas_Top(lpy + fontSize + 2)
+                stateDot.Visibility("Collapsed").IsHitTestVisible("False")
             } else {
                 centerR := innerR + (radius - innerR) * this.centerPosRatio
                 cpx := Round(cx + centerR * Cos(midRad))
@@ -355,9 +361,15 @@ class MenuWheelGui {
                 lbl.Text(sec.Name)
                 lbl.FontFamily("Segoe UI Variable Display, Segoe UI, sans-serif")
                 lbl.FontSize(fontSize).Foreground(this.normalText).FontWeight("SemiBold")
-                lbl.TextAlignment("Center")
-                lbl.TextTrimming("CharacterEllipsis")
-                lbl.Canvas_Left(cpx - 39).Canvas_Top(cpy - 8).Width(78).IsHitTestVisible("False")
+                lbl.TextAlignment("Center").TextTrimming("CharacterEllipsis")
+                lbl.Width(Round(78 * this.dpiScale)).Canvas_Left(cpx - Round(39 * this.dpiScale)).Canvas_Top(cpy - 8).IsHitTestVisible("False")
+
+                ; 运行状态色点（默认隐藏，放在文本下方居中）
+                dotSize := Round(8 * this.dpiScale)
+                stateDot := canvas.Add("Ellipse").Name("StateDot_" idx)
+                stateDot.Width(dotSize).Height(dotSize)
+                stateDot.Canvas_Left(cpx - Round(dotSize / 2)).Canvas_Top(cpy + fontSize + 2)
+                stateDot.Visibility("Collapsed").IsHitTestVisible("False")
             }
         }
 
@@ -407,13 +419,34 @@ class MenuWheelGui {
         } else {
             this.swipe := ""
         }
+
+        ; 显示宏运行状态颜色
+        tableItem := MySoftData.TableInfo[3]
+        Loop itemCount {
+            idx := A_Index
+            macroIndex := (this.MenuIndex - 1) * 8 + idx
+            isWorkRunning := tableItem.IsWorkIndexArr.Length >= macroIndex && tableItem.IsWorkIndexArr[macroIndex] != 0
+            state := isWorkRunning ? 1 : (tableItem.ColorStateArr.Length >= macroIndex ? tableItem.ColorStateArr[macroIndex] : 0)
+            if (state > 0 && MacroStateColors.Has(state))
+                this.sectors[idx].RenderState(this, MacroStateColors[state])
+        }
+
         this._aliveHwnd := this.ui.wpfHwnd
         this.Gui := { Hwnd: this.ui.wpfHwnd }
-        WindowHotkeyManager.Register(this, MenuWheelGui.Hotkeys, this.OnSoftKey.Bind(this), this._IsAlive.Bind(this))
+        ; 注册数字键热键（窗口打开期间全局有效，关闭时注销）
+        this._hkIds := WinHotkey.Register(MenuWheelGui.Hotkeys, ObjBindMethod(this, "_OnHotkey"))
     }
 
-    _IsAlive() {
-        return WinExist("ahk_id " this._aliveHwnd)
+    _OnHotkey(key) {
+        idx := 0
+        for i, k in MenuWheelGui.Hotkeys {
+            if (k == key) {
+                idx := i
+                break
+            }
+        }
+        if (idx > 0 && idx <= this.sectors.Length)
+            this.DoSelect(idx)
     }
 
     static _H(menu, idx) {
@@ -464,7 +497,10 @@ class MenuWheelGui {
 
     _Cleanup() {
         this.ToggleFunc(false)
-        WindowHotkeyManager.Unregister(this)
+        if (this._hkIds.Length > 0) {
+            WinHotkey.UnregisterAll(this._hkIds)
+            this._hkIds := []
+        }
         this.isOpen := false
         if (IsObject(this.swipe))
             this.swipe.Stop()
@@ -491,6 +527,22 @@ class MenuWheelGui {
     OnRadialMenuSelect(ArcNr, MenuIndex) {
         tableItem := MySoftData.TableInfo[3]
         macroIndex := (MenuIndex - 1) * 8 + ArcNr
+        triggerType := tableItem.TriggerTypeArr[macroIndex]
+
+        ; 开关模式：与按键宏保持一致，统一走 OnToggleTriggerMacro
+        if (triggerType == 4) {
+            WorkerIndex := tableItem.IsWorkIndexArr[macroIndex]
+            if (WorkerIndex != 0) {
+                ; Worker 运行中 → 停止
+                MyStopMacro(tableItem.Index, macroIndex)
+                return
+            }
+            ; 未运行或主进程内运行 → 走统一的开关逻辑（管理 ToggleStateArr）
+            OnToggleTriggerMacro(tableItem.Index, macroIndex)
+            return
+        }
+
+        ; 非开关模式：直接启动
         SetTableItemState(tableItem.index, macroIndex, 1)
         OnTriggerMacroKeyAndInit(tableItem, tableItem.MacroArr[macroIndex], macroIndex)
     }
@@ -527,6 +579,18 @@ class MenuWheelGui {
                 { ControlName: "Wedge_" p, PropertyName: "Stroke", Value: menu.selectedStroke },
                 { ControlName: "Wedge_" p, PropertyName: "StrokeThickness", Value: String(menu.selectedThickness) },
                 { ControlName: "Label_" p, PropertyName: "Foreground", Value: menu.selectedText }
+            ])
+        }
+
+        ; 按宏运行状态渲染色点（使用全局 MacroStateColors）
+        RenderState(menu, stateColor) {
+            p := this.Index
+            ui := menu.ui
+            if (!IsObject(ui))
+                return
+            ui.BatchUpdate([
+                { ControlName: "StateDot_" p, PropertyName: "Fill", Value: stateColor },
+                { ControlName: "StateDot_" p, PropertyName: "Visibility", Value: "Visible" }
             ])
         }
     }

--- a/Gui/TargetGui.ahk
+++ b/Gui/TargetGui.ahk
@@ -8,6 +8,8 @@ class TargetGui {
         this.GuiHeight := 64
 
         this.SureAction := ""
+        this._hkIds := []
+        this._lbuttonCb := ""
     }
 
     ShowGui() {
@@ -19,6 +21,26 @@ class TargetGui {
         }
         MyColorPanel.SureAction := this.SureAction
         MyColorPanel.ShowGui()
+        ; 注册方向键热键（目标窗口活动期间有效）
+        if (this._hkIds.Length == 0) {
+            this._hkIds := WinHotkey.Register(["Left", "Right", "Up", "Down"], ObjBindMethod(this, "_OnHotkey"))
+        }
+        ; 订阅 LButton 热键（目标窗口活动期间有效）
+        if (!this._lbuttonCb) {
+            this._lbuttonCb := ObjBindMethod(this, "_OnLButton")
+            WinHotkey.SubscribeMouse("LButton", this._lbuttonCb)
+        }
+    }
+
+    HideGui() {
+        if (this._hkIds.Length > 0) {
+            WinHotkey.UnregisterAll(this._hkIds)
+            this._hkIds := []
+        }
+        if (this._lbuttonCb) {
+            WinHotkey.UnsubscribeMouse("LButton", this._lbuttonCb)
+            this._lbuttonCb := ""
+        }
     }
 
     AddGui() {
@@ -44,6 +66,10 @@ class TargetGui {
     }
 
     OnLButtonUp(*) {
+        this._OnLButton()
+    }
+
+    _OnLButton(*) {
         if (this.Gui == "")
             return
         style := WinGetStyle(this.Gui.Hwnd)
@@ -51,6 +77,31 @@ class TargetGui {
         if (!isVisible)
             return
 
+        MyColorPanel.RefreshCoord()
+        MyColorPanel.RefreshMapImage()
+    }
+
+    _OnHotkey(key) {
+        if (this.Gui == "")
+            return
+        style := WinGetStyle(this.Gui.Hwnd)
+        isVisible := (style & 0x10000000)
+        if (!isVisible)
+            return
+
+        this.Gui.GetPos(&x, &y, &w, &h)
+        if (key == "Left")
+            x -= 1
+        else if (key == "Right")
+            x += 1
+        else if (key == "Up")
+            y -= 1
+        else if (key == "Down")
+            y += 1
+        else
+            return
+
+        this.Gui.Move(x, y)
         MyColorPanel.RefreshCoord()
         MyColorPanel.RefreshMapImage()
     }

--- a/Gui/UIMacroGui.ahk
+++ b/Gui/UIMacroGui.ahk
@@ -6,13 +6,6 @@ class UIMacroGui {
     static STATE_PAUSED := 2     ; 暂停中（黄色）
     static STATE_STOPPED := 3    ; 停止/终止（红色，5秒后自动恢复）
 
-    ; 状态色点颜色
-    static StateColors := Map(
-        UIMacroGui.STATE_RUNNING, "#FF4CAF50",
-        UIMacroGui.STATE_PAUSED,  "#FFFFC107",
-        UIMacroGui.STATE_STOPPED, "#FFF44336"
-    )
-
     __new() {
         this.PanelMap := Map()       ; foldIndex -> panelInfo
         this.PanelTimers := Map()     ; foldIndex -> FuncObj（SetTimer回调引用）
@@ -338,6 +331,11 @@ class UIMacroGui {
             btn.Padding("2,0,2,0")
 
             sp := btn.Add("StackPanel").Orientation("Horizontal").HorizontalAlignment("Center")
+
+            ; 运行状态色点（默认隐藏）
+            sp.Add("Ellipse").Name(item.name "_State")
+                .Width(8).Height(8).VerticalAlignment("Center").Margin("0,0,3,0")
+                .Visibility("Collapsed").IsHitTestVisible("False")
 
             if (item.icon != "") {
                 fullIconPath := this.GetFullIconPath(item.icon)
@@ -850,10 +848,10 @@ class UIMacroGui {
                     try {
                         if (state == UIMacroGui.STATE_DEFAULT) {
                             panelInfo.ui.Update(stateName, "Visibility", "Collapsed")
-                        } else if (UIMacroGui.StateColors.Has(state)) {
-                            color := UIMacroGui.StateColors[state]
+                        } else if (MacroStateColors.Has(state)) {
+                            color := MacroStateColors[state]
                             panelInfo.ui.Update(stateName, "Visibility", "Visible")
-                            panelInfo.ui.Update(stateName, "Background", color)
+                            panelInfo.ui.Update(stateName, "Fill", color)
                         }
                     }
                     ; ui.Update() 后恢复位置（对齐 MovePanel L171-179）

--- a/Gui/VerticalSlider.ahk
+++ b/Gui/VerticalSlider.ahk
@@ -14,6 +14,7 @@ class VerticalSlider {
         this.IsDragging := false
         this.DragOffsetPosY := 0      ;拖拽偏移位置Y
         this.DragAction := this.DragHandler.Bind(this)
+        this._wheelCb := ""
     }
 
     ;内凹像素， 左边偏移（text左边点击不灵敏）
@@ -43,6 +44,19 @@ class VerticalSlider {
         this.ShowSlider := this.ContentHeight > this.AeraHeight
         this.AreaCon.Visible := this.ShowSlider
         this.BarCon.Visible := this.ShowSlider
+
+        ; 滚轮热键：仅在滑块可见时订阅
+        if (this.ShowSlider && !this._wheelCb) {
+            this._wheelCb := ObjBindMethod(this, "_OnWheel")
+            WinHotkey.SubscribeMouse("WheelUp", this._wheelCb)
+            WinHotkey.SubscribeMouse("WheelDown", this._wheelCb)
+        }
+        else if (!this.ShowSlider && this._wheelCb) {
+            WinHotkey.UnsubscribeMouse("WheelUp", this._wheelCb)
+            WinHotkey.UnsubscribeMouse("WheelDown", this._wheelCb)
+            this._wheelCb := ""
+        }
+
         if (!this.ShowSlider)
             return
 
@@ -70,8 +84,16 @@ class VerticalSlider {
         HotIfWinActive
     }
 
+    _OnWheel(key) {
+        this.OnScrollWheel(key)
+    }
+
     OnScrollWheel(key) {
         if (!this.ShowSlider)
+            return
+
+        ; 主窗口不可见时不处理（避免对隐藏窗口操作导致窗口重新显示）
+        if (MySoftData.MyGui != "" && !WinExist("ahk_id " MySoftData.MyGui.Hwnd))
             return
 
         isDown := InStr(key, "Down", "Off") ? true : false

--- a/Main/AssetUtil.ahk
+++ b/Main/AssetUtil.ahk
@@ -665,7 +665,7 @@ ReadTableItemInfo(index) {
         defaultFoldInfo.FoldStateArr := [false]
         defaultFoldInfo.ForbidStateArr := [false]
 
-        defaultFoldInfo.TKTypeArr := [1]
+        defaultFoldInfo.TKTypeArr := [4]
         defaultFoldInfo.TKArr := [""]
         defaultFoldInfo.HoldTimeArr := [500]
         savedFoldInfoStr := JSON.stringify(defaultFoldInfo, 0)
@@ -807,7 +807,7 @@ GetTableItemDefaultInfo(index) {
         savedForbidArrStr := "0π0π0π0π0π0π0π0"
         savedRemarkArrStr := "πππππππ"
         savedLoopCountStr := "1π1π1π1π1π1π1π1"
-        savedTriggerTypeStr := "1π1π1π1π1π1π1π1"
+        savedTriggerTypeStr := "4π4π4π4π4π4π4π4"
         savedSerialeArrStr := "3π4π5π6π7π8π12π13"
         savedTimingSerialStr :=
             "Timing3πTiming4πTiming5πTiming6πTiming7πTiming8πTiming12πTiming13"

--- a/Main/BindUtil.ahk
+++ b/Main/BindUtil.ahk
@@ -10,7 +10,6 @@ BindKey() {
     BindShortcut(ToolCheckInfo.FreePasteHotKey, OnToolFreePaste)
     BindShortcut(ToolCheckInfo.ToolRecordMacroHotKey, OnHotToolRecordMacro)
     InitTriggerKeyMap()
-    BindSoftHotKey()
     BindMenuHotKey()
     BindUIPanelHotKey()
     BindTabHotKey()
@@ -29,9 +28,7 @@ BindShortcut(triggerInfo, action) {
     else {
         isCombo := IsComboKey(triggerInfo)
         mapKey := StrLower(Trim(triggerInfo, "~"))
-        if (WindowHotkeyManager.IsManaged(mapKey)) {
-            key := "$~" mapKey
-        } else if (isCombo) {
+        if (isCombo) {
             key := triggerInfo
         }
         else {
@@ -288,8 +285,6 @@ BindMenuHotKey() {
             continue
 
         oriKey := FoldInfo.TKArr[index]
-        if (WindowHotkeyManager.IsManaged(StrLower(oriKey)))
-            continue
         isCombo := IsComboKey(oriKey)
         if (isCombo) {
             key := oriKey
@@ -353,8 +348,6 @@ BindUIPanelHotKey() {
             continue
 
         oriKey := FoldInfo.TKArr[Index]
-        if (WindowHotkeyManager.IsManaged(StrLower(oriKey)))
-            continue
 
         key := "$*" oriKey
         foldIndex := Index
@@ -398,7 +391,6 @@ BindTabHotKey() {
             cacheKey := rawKey "|" tableIndex "|" index
             if (!keyCache.Has(cacheKey)) {
                 cacheData := {
-                    isManaged: WindowHotkeyManager.IsManaged(StrLower(rawKey)),
                     isCombo: IsComboKey(rawKey),
                     isJoy: !!RegExMatch(rawKey, "Joy"),
                     isHotstring: SubStr(rawKey, 1, 1) == ":",
@@ -414,9 +406,6 @@ BindTabHotKey() {
                 keyCache.Set(cacheKey, cacheData)
             }
             cache := keyCache[cacheKey]
-
-            if (cache.isManaged)
-                continue
 
             key := cache.isCombo ? rawKey : cache.keyPrefix rawKey
             actionArr := GetMacroAction(tableIndex, index)
@@ -555,14 +544,6 @@ InitTriggerKeyMap() {
             MySoftData.TriggerKeyMap[key].AddData(info)
         }
     }
-
-    for index, value in MySoftData.SoftHotKeyArr {
-        key := LTrim(value, "~")
-        key := StrLower(key)
-        if (!MySoftData.TriggerKeyMap.Has(key)) {
-            MySoftData.TriggerKeyMap[key] := TriggerKeyData(key)
-        }
-    }
 }
 
 GetMacroAction(tableIndex, index) {
@@ -608,36 +589,6 @@ OnTriggerKeyUp(tableIndex, itemIndex, *) {
 
     Data := MySoftData.TriggerKeyMap[key]
     Data.OnTriggerKeyUp()
-}
-
-BindSoftHotKey() {
-    for index, value in MySoftData.SoftHotKeyArr {
-        mapKey := Trim(value, "~")
-        mapKey := StrLower(mapKey)
-        isCombo := IsComboKey(mapKey)
-
-        if (WindowHotkeyManager.IsManaged(mapKey)) {
-            key := "$~" mapKey
-        } else if (isCombo) {
-            key := value
-        }
-        else if (SubStr(value, 1, 1) == "~") {
-            key := "$" value
-        }
-        else {
-            key := "$*" value
-        }
-        actionDown := OnBindKeyDown.Bind(value)
-        actionUp := OnBindKeyUp.Bind(value)
-
-        try {
-            Hotkey(key, actionDown, "On")
-            if (!isCombo)
-                Hotkey(key " up", actionUp, "On")
-        }
-        catch as e {
-        }
-    }
 }
 
 GetBindMacroAction(key) {

--- a/Main/DataClass.Ahk
+++ b/Main/DataClass.Ahk
@@ -306,8 +306,6 @@ class SoftData {
         this.VarListenHeight := 420
 
         this.TriggerKeyMap := Map()     ;所有的按键宏，包括软件自身的快捷键
-        this.SoftHotKeyArr := ["~WheelUp", "~WheelDown", "~LButton", "~Left", "~Right", "~Up", "~Down", "~Enter", "~1",
-            "~2", "~3", "~4", "~5", "~6", "~7", "~8", "~F5", "~F6", "~Delete", "~NumpadDot"]
 
         this.SelectAreaAction := "" ;左键框选范围回调   显示框选范围       正常
         this.GetAreaAction := ""    ;左键框选范围回调   不显示框选范围      系统截图获取截图范围

--- a/Main/GlobalUtil.ahk
+++ b/Main/GlobalUtil.ahk
@@ -115,6 +115,8 @@ global MyMsgBoxContent := MsgBoxContent
 global MyToolTipContent := ToolTipContent
 global MyMacroCount := MacroCount
 global MyViGJoySetState := ViGJoySetState
+;宏运行状态颜色（0默认 1运行中 2暂停 3停止）
+global MacroStateColors := Map(1, "#FF4CAF50", 2, "#FFFFC107", 3, "#FFF44336")
 ;数组相关
 global MySetGlobalArray := SetGlobalArray
 global MyCloneGlobalArray := CloneGlobalArray

--- a/Main/TriggerKeyData.ahk
+++ b/Main/TriggerKeyData.ahk
@@ -29,32 +29,6 @@ class TriggerKeyData {
     }
 
     InitState() {
-        this.IsSoftHotKey := false
-        for index, value in MySoftData.SoftHotKeyArr {
-            key := LTrim(value, "~")
-            key := StrLower(key)
-            if (this.Key == key) {
-                this.IsSoftHotKey := true
-                break
-            }
-        }
-    }
-
-    IsOnlySoftHotkey() {
-        if (this.OriDownArr.Length >= 1)
-            return false
-        if (this.OriLoosenArr.Length >= 1)
-            return false
-        if (this.OriLoosenStopArr.Length >= 1)
-            return false
-        if (this.OriTogArr.Length >= 1)
-            return false
-        if (this.OriHoldArr.Length >= 1)
-            return false
-        if (this.OriDblClickArr.Length >= 1)
-            return false
-
-        return true
     }
 
     AddData(info) {
@@ -124,10 +98,6 @@ class TriggerKeyData {
 
     OnTriggerKeyDown() {
         this.UpdataArr()
-        this.HandleSoftHotKeyDown()
-
-        if (WindowHotkeyManager.IsManaged(this.Key) && WindowHotkeyManager.IsAnyWindowActive(this.Key))
-            return
 
         ;双击检测逻辑
         currentTime := A_TickCount
@@ -161,10 +131,6 @@ class TriggerKeyData {
 
     OnTriggerKeyUp() {
         this.UpdataArr()
-        this.HandleSoftHotKeyUp()
-
-        if (WindowHotkeyManager.IsManaged(this.Key) && WindowHotkeyManager.IsAnyWindowActive(this.Key))
-            return
 
         for index, value in this.LoosenArr {
             value.Action()
@@ -210,65 +176,6 @@ class TriggerKeyData {
 
         if (AreKeysPressed(keyCombo))
             info.Action()
-    }
-
-    HandleSoftHotKeyDown() {
-        if (!this.IsSoftHotKey)
-            return
-
-        if (this.Key == "wheelup" || this.Key == "wheeldown") {
-            if (MyMouseInfo.CheckIfMatch("RMTv⎖⎖")) {
-                MySlider.OnScrollWheel(this.Key)
-            }
-
-            if (MyMouseInfo.CheckIfMatch("RMT-FreePaste⎖⎖")) {
-                MyFreePasteGui.OnScrollWheel(this.Key)
-            }
-
-            MyCMDTipGui.OnScrollWheel(this.Key)
-        }
-
-        isArrowKey1 := this.Key == "left" || this.Key == "right"
-        isArrowKey2 := this.Key == "up" || this.Key == "down"
-        isArrowKey := isArrowKey1 || isArrowKey2
-        if (isArrowKey) {
-            MyTargetGui.OnArrowKeyDown(this.Key)
-        }
-
-        if (this.Key == "lbutton") {
-            if (MySoftData.SelectAreaAction != "") {
-                SelectArea()
-            }
-
-            if (MySoftData.GetAreaAction != "") {
-                OnGetSelectAreaDown(this.Key)
-            }
-        }
-
-        if (WindowHotkeyManager.IsManaged(this.Key) && WindowHotkeyManager.HandleKey(this.Key, true))
-            return
-    }
-
-    HandleSoftHotKeyUp() {
-        if (!this.IsSoftHotKey)
-            return
-
-        if (this.Key == "lbutton") {
-            if (MyMouseInfo.CheckIfMatch("RMT-Target⎖⎖")) {
-                MyTargetGui.OnLButtonUp(this.Key)
-            }
-
-            if (MySoftData.GetAreaAction != "") {
-                OnGetSelectAreaUp(this.Key)
-            }
-        }
-
-        if (this.Key == "enter") {
-            MyColorPanel.OnEnterUp(this.Key)
-        }
-
-        if (WindowHotkeyManager.IsManaged(this.Key) && WindowHotkeyManager.HandleKey(this.Key, false))
-            return
     }
 }
 

--- a/Main/UIUtil.ahk
+++ b/Main/UIUtil.ahk
@@ -10,6 +10,7 @@ InitUI() {
         MyGui.BackColor := BGColor
 
     MySoftData.MyGui := MyGui
+    MyGui.OnEvent("Close", OnGuiClose)
     AddUI()
     CustomTrayMenu()
     OnOpen()
@@ -40,6 +41,16 @@ OnOpen() {
     RefreshGui()
 }
 
+; 主窗口关闭时清理所有鼠标热键订阅
+OnGuiClose(*) {
+    WinHotkey.UnsubscribeAllMouse()
+    ; 重置各组件的订阅状态，以便窗口重新显示时能重新订阅
+    MySlider._wheelCb := ""
+    MyCMDTipGui._wheelCb := ""
+    MyFreePasteGui._wheelCb := ""
+    MyTargetGui._lbuttonCb := ""
+}
+
 RefreshGui() {
     LastWinPosStr := IniRead(IniFile, IniSection, "LastWinPos", "")
     WinPosArr := StrSplit(LastWinPosStr, "π")
@@ -53,6 +64,9 @@ RefreshGui() {
         if (isXValid && isYValid) {
             MySoftData.MyGui.Show(Format("x{} y{} w{} h{}", WinPosArr[1], WinPosArr[2], 1070, 590))
             RefreshListenVarGui()
+            ; 恢复滑块滚轮热键订阅（窗口重新打开后需要重新订阅）
+            if (MySlider.tableItem != "" && MySlider.ShowSlider)
+                MySlider.SwitchTab(MySlider.tableItem)
             return
         }
     }
@@ -65,6 +79,9 @@ RefreshGui() {
 
     MySoftData.MyGui.Show(Format("w{} h{}", 1070, 590))
     RefreshListenVarGui()
+    ; 恢复滑块滚轮热键订阅（窗口重新打开后需要重新订阅）
+    if (MySlider.tableItem != "" && MySlider.ShowSlider)
+        MySlider.SwitchTab(MySlider.tableItem)
 }
 
 RefreshListenVarGui(isForce := false) {

--- a/Main/WindowHotkeyManager.ahk
+++ b/Main/WindowHotkeyManager.ahk
@@ -1,129 +1,112 @@
 #Requires AutoHotkey v2.0
 
-class WindowHotkeyManager {
-    static KeyHandlers := Map()
+; 窗口级热键管理器：替代原 WindowHotkeyManager 和全局 SoftHotKeyArr
+; 键盘键 → 各组件独立用 Win32 RegisterHotKey，显示时注册、隐藏时注销
+; 鼠标键（Wheel/LButton）→ 集中注册一次，按需订阅/取消订阅
 
-    static Register(instance, hotkeys, callback, aliveCheck := "") {
-        for key in hotkeys {
-            key := StrLower(key)
-            isFirst := !WindowHotkeyManager.KeyHandlers.Has(key)
-            if (isFirst)
-                WindowHotkeyManager.KeyHandlers[key] := []
-            duplicate := false
-            for h in WindowHotkeyManager.KeyHandlers[key] {
-                if (h.instance == instance) {
-                    h.callback := callback
-                    h.aliveCheck := aliveCheck
-                    duplicate := true
-                    break
-                }
-            }
-            if (!duplicate)
-                WindowHotkeyManager.KeyHandlers[key].Push({
-                    instance: instance,
-                    callback: callback,
-                    aliveCheck: aliveCheck
-                })
-        }
-    }
+class WinHotkey {
+    static _nextId := 0xA000          ; RegisterHotKey 起始 ID
+    static _handlers := Map()         ; id → { key, callback }
+    static _mouseHandlers := Map()    ; key → [callback1, callback2, ...]  （集中式鼠标热键）
+    static _wmHooked := false
 
-    static Unregister(instance) {
-        keysToClean := []
-        for key, handlers in WindowHotkeyManager.KeyHandlers {
-            i := handlers.Length
-            while (i > 0) {
-                if (handlers[i].instance == instance)
-                    handlers.RemoveAt(i)
-                i--
-            }
-            if (handlers.Length == 0)
-                keysToClean.Push(key)
-        }
-        for k in keysToClean
-            WindowHotkeyManager.KeyHandlers.Delete(k)
-    }
+    ; ========== 键盘热键（各组件独立注册/注销）==========
 
-    static IsManaged(key) {
-        return WindowHotkeyManager.KeyHandlers.Has(StrLower(key))
-    }
-
-    static HandleKey(key, isDown) {
-        key := StrLower(key)
-        WindowHotkeyManager._CleanupDead(key)
-        if (!WindowHotkeyManager.KeyHandlers.Has(key))
-            return false
-        handlers := WindowHotkeyManager.KeyHandlers[key]
-        for h in handlers {
-            if (WindowHotkeyManager._IsActive(h)) {
-                h.callback.Call(key, isDown)
-                return true
+    ; 注册键盘热键（Win32 RegisterHotKey，系统级拦截）
+    ; 返回已注册的 ID 数组，供调用者后续 Unregister 时使用
+    static Register(keys, callback) {
+        hwnd := A_ScriptHwnd
+        ids := []
+        for idx, k in keys {
+            vk := GetKeyVK(k)
+            if (!vk)
+                continue
+            id := WinHotkey._nextId++
+            r := DllCall("RegisterHotKey", "Ptr", hwnd, "Int", id, "UInt", 0, "UInt", vk)
+            if (r) {
+                WinHotkey._handlers[id] := { key: k, cb: callback }
+                ids.Push(id)
             }
         }
-        return false
-    }
-
-    static IsAnyWindowActive(key) {
-        key := StrLower(key)
-        WindowHotkeyManager._CleanupDead(key)
-        if (!WindowHotkeyManager.KeyHandlers.Has(key))
-            return false
-        handlers := WindowHotkeyManager.KeyHandlers[key]
-        for h in handlers {
-            if (WindowHotkeyManager._IsActive(h))
-                return true
+        if (WinHotkey._handlers.Count > 0 && !WinHotkey._wmHooked) {
+            OnMessage(0x0312, ObjBindMethod(WinHotkey, "_OnWMHotkey"))
+            WinHotkey._wmHooked := true
         }
-        return false
+        return ids
     }
 
-    static _IsActive(h) {
-        if (h.aliveCheck != "" && IsObject(h.aliveCheck)) {
-            try
-                return h.aliveCheck.Call()
-            catch
-                return false
+    ; 注销指定 ID 的键盘热键
+    static UnregisterId(id) {
+        if (WinHotkey._handlers.Has(id)) {
+            DllCall("UnregisterHotKey", "Ptr", A_ScriptHwnd, "Int", id)
+            WinHotkey._handlers.Delete(id)
         }
-        hwnd := WindowHotkeyManager.GetInstanceHwnd(h.instance)
-        return !!(hwnd && WinActive("ahk_id " hwnd))
     }
 
-    static _CleanupDead(key) {
-        if (!WindowHotkeyManager.KeyHandlers.Has(key))
+    ; 批量注销键盘热键
+    static UnregisterAll(ids := "") {
+        if (ids != "" && ids.Length > 0)
+            for id in ids
+                WinHotkey.UnregisterId(id)
+    }
+
+    ; ========== 鼠标热键（集中式：全局只注册一次，组件按需订阅）==========
+
+    ; 订阅鼠标热键（首次订阅时自动注册全局 AHK 热键）
+    static SubscribeMouse(key, callback) {
+        if (!WinHotkey._mouseHandlers.Has(key))
+            WinHotkey._mouseHandlers[key] := []
+        WinHotkey._mouseHandlers[key].Push(callback)
+
+        ; 首次订阅时注册全局热键（~前缀：不拦截原始事件，允许透传给其他程序）
+        if (WinHotkey._mouseHandlers[key].Length == 1) {
+            try Hotkey("~" key, ObjBindMethod(WinHotkey, "_OnMouseKey", key), "On")
+        }
+    }
+
+    ; 取消订阅鼠标热键（无订阅者时自动注销全局热键）
+    static UnsubscribeMouse(key, callback) {
+        if (!WinHotkey._mouseHandlers.Has(key))
             return
-        handlers := WindowHotkeyManager.KeyHandlers[key]
-        i := handlers.Length
-        while (i > 0) {
-            h := handlers[i]
-            isAlive := true
-            hwnd := WindowHotkeyManager.GetInstanceHwnd(h.instance)
-            if (hwnd) {
-                if (!WinExist("ahk_id " hwnd))
-                    isAlive := false
-            } else {
-                if (h.aliveCheck != "" && IsObject(h.aliveCheck)) {
-                    try
-                        isAlive := h.aliveCheck.Call()
-                    catch
-                        isAlive := false
-                } else {
-                    isAlive := false
-                }
-            }
-            if (!isAlive)
-                handlers.RemoveAt(i)
-            i--
+        arr := WinHotkey._mouseHandlers[key]
+        ; 移除指定的回调
+        newArr := []
+        for cb in arr {
+            if (cb != callback)
+                newArr.Push(cb)
         }
-        if (handlers.Length == 0)
-            WindowHotkeyManager.KeyHandlers.Delete(key)
+        if (newArr.Length == 0) {
+            WinHotkey._mouseHandlers.Delete(key)
+            try Hotkey("~" key, "Off")
+        } else {
+            WinHotkey._mouseHandlers[key] := newArr
+        }
     }
 
-    static GetInstanceHwnd(instance) {
-        try {
-            if (IsObject(instance.Gui))
-                return instance.Gui.Hwnd
+    ; 取消订阅所有鼠标热键（主窗口关闭时调用）
+    static UnsubscribeAllMouse() {
+        for key in WinHotkey._mouseHandlers {
+            try Hotkey("~" key, "Off")
         }
-        try {
-            return instance.GetWinHwnd()
+        WinHotkey._mouseHandlers.Clear()
+    }
+
+    ; 内部：鼠标热键统一分发
+    static _OnMouseKey(key, *) {
+        if (!WinHotkey._mouseHandlers.Has(key))
+            return
+        for cb in WinHotkey._mouseHandlers[key] {
+            try cb.Call(key)
         }
-        return 0
+    }
+
+    ; ========== WM_HOTKEY 消息处理 ==========
+
+    static _OnWMHotkey(wParam, lParam, msg, hwnd) {
+        id := wParam & 0xFFFFFFFF
+        if (WinHotkey._handlers.Has(id)) {
+            entry := WinHotkey._handlers[id]
+            entry.cb.Call(entry.key)
+        }
     }
 }


### PR DESCRIPTION
- 移除过时的SoftHotKeyArr及相关绑定逻辑
- 改用Win32 RegisterHotKey实现窗口级键盘热键，按需注册注销
- 重构鼠标热键为集中式管理，组件按需订阅/取消订阅
- 全局统一管理宏状态颜色配置
- 优化各GUI组件的热键订阅逻辑，避免重复注册和内存泄漏
- 调整默认触发器类型为4（开关模式）
- 修复滚轮热键、快捷键的生命周期管理问题