### PR TITLE
fix: 在保存配置前终止所有运行宏

### DIFF
--- a/Main/RMTUtil.ahk
+++ b/Main/RMTUtil.ahk
@@ -1,4 +1,4 @@
-﻿#Requires AutoHotkey v2.0
+#Requires AutoHotkey v2.0
 
 ;资源保存（带脏检查优化：只写入实际发生变化的配置项）
 OnSaveSetting(*) {
@@ -6,6 +6,8 @@ OnSaveSetting(*) {
     isValid := CheckAllValueSettingValid()
     if (!isValid)
         return
+
+    OnKillAllMacro()
 
     if (MyWorkPool != "") {
         MyWorkPool.Clear()


### PR DESCRIPTION
在保存配置前调用终止所有宏的函数，避免配置保存时出现资源占用冲突