### PR TITLE
chore: 升级版本号到1.2F18并修复脚本编码问题

### DIFF
--- a/PackRMT.ps1
+++ b/PackRMT.ps1
@@ -1,4 +1,4 @@
-# RMT 自动打包脚本
+﻿# RMT 自动打包脚本
 # 使用 Ahk2Exe.exe 编译 Work.ahk 为 Work.exe
 # 此脚本需要编码格式为UTF-8 BOM 或者 UTF-16才能正常运行
 $Host.UI.RawUI.WindowTitle = "RMT 打包工具"

--- a/RMT.ahk
+++ b/RMT.ahk
@@ -1,5 +1,5 @@
 #Requires AutoHotkey v2.0
-global RMT_VERSION := "1.2F16"
+global RMT_VERSION := "1.2F18"
 #Include Main\SelfCheck.ahk
 ; SelfCheckMissingFiles()   ;开发日常注释，大正式包启用，方便动态修改一些文件
 #Include Main\AssetUtil.ahk


### PR DESCRIPTION
将PackRMT.ps1的首行添加了BOM头，同时更新RMT.ahk的版本标识