### PR TITLE
refactor: 提取工作池启用检查逻辑为公共函数

### DIFF
--- a/Main/AssetUtil.ahk
+++ b/Main/AssetUtil.ahk
@@ -2247,3 +2247,8 @@ SafeReload() {
         Reload()
     }
 }
+
+WorkPoolEnabled() {
+    global MyWorkPool
+    return MyWorkPool != "" && IsObject(MyWorkPool) && (MyWorkPool.isDynamic || MyWorkPool.maxSize >= 1)
+}

--- a/Main/BindUtil.ahk
+++ b/Main/BindUtil.ahk
@@ -623,7 +623,7 @@ OnToggleTriggerMacro(tableIndex, itemIndex) {
     tableItem := MySoftData.TableInfo[tableIndex]
     macro := tableItem.MacroArr[itemIndex]
 
-    if (MyWorkPool.isDynamic || MyWorkPool.maxSize >= 1) {
+    if (WorkPoolEnabled()) {
         SetTableItemState(tableItem.Index, itemIndex, 1)
         MyWorkPool.PrepareItemRun(tableIndex, itemIndex)
         GraphPoolLog("宏触发", Format("tab={1} item={2} 来源=开关", tableIndex, itemIndex))
@@ -660,7 +660,7 @@ TriggerMacroHandler(tableIndex, itemIndex, *) {
         return
 
     SetTableItemState(tableItem.Index, itemIndex, 1)
-    if (MyWorkPool.isDynamic || MyWorkPool.maxSize >= 1) {
+    if (WorkPoolEnabled()) {
         if (isWork)
             GraphPoolLog("宏触发恢复", Format("tab={1} item={2} 清理上次残留", tableIndex, itemIndex))
         MyWorkPool.PrepareItemRun(tableIndex, itemIndex)

--- a/Main/Util/GraphMacroUtil.ahk
+++ b/Main/Util/GraphMacroUtil.ahk
@@ -66,7 +66,7 @@ ShouldUseGraphWorkers() {
     global MyWorkPool
     if (MySoftData.isWorker)
         return true
-    return MyWorkPool != "" && (MyWorkPool.isDynamic || MyWorkPool.maxSize >= 1)
+    return WorkPoolEnabled()
 }
 
 ShouldSkipGraphNextDispatch(cmdStr) {


### PR DESCRIPTION
将多处重复的工作池可用性判断代码提取为WorkPoolEnabled公共函数，简化代码并统一判断逻辑，减少重复代码维护成本