### PR TITLE
refactor(ipc): 優化 RingBuffer 效能與修復 WorkPool 排程器崩潰問題

### DIFF
--- a/Main/Util/RingBuffer.ahk
+++ b/Main/Util/RingBuffer.ahk
@@ -130,7 +130,7 @@ EscapeIPC(str) {
 }
 
 UnescapeIPC(str) {
-    if StrIn(str, IPC_ESC) {
+    if InStr(str, IPC_ESC) {
         str := StrReplace(str, IPC_ESC IPC_REC, IPC_REC)
         str := StrReplace(str, IPC_ESC IPC_SEP, IPC_SEP)
         str := StrReplace(str, IPC_ESC IPC_ESC, IPC_ESC)

--- a/Main/Util/RingBuffer.ahk
+++ b/Main/Util/RingBuffer.ahk
@@ -118,25 +118,28 @@ R1 輕量化分隔符協定 (取代 JSON)
 - 指令重構：改用雙字元 Opcode (如 SV、SA、JY、TR 等) 進行封包路由與分派。
 ====================================================================
 */
+global IPC_SEP := Chr(1)
+global IPC_REC := Chr(2)
+global IPC_ESC := Chr(3)
 
 EscapeIPC(str) {
-    str := StrReplace(str, Chr(3), Chr(3) Chr(3))
-    str := StrReplace(str, Chr(1), Chr(3) Chr(1))
-    str := StrReplace(str, Chr(2), Chr(3) Chr(2))
+    str := StrReplace(str, IPC_ESC, IPC_ESC IPC_ESC)
+    str := StrReplace(str, IPC_SEP, IPC_ESC IPC_SEP)
+    str := StrReplace(str, IPC_REC, IPC_ESC IPC_REC)
     return str
 }
 
 UnescapeIPC(str) {
-    str := StrReplace(str, Chr(3) Chr(2), Chr(2))
-    str := StrReplace(str, Chr(3) Chr(1), Chr(1))
-    str := StrReplace(str, Chr(3) Chr(3), Chr(3))
+    str := StrReplace(str, IPC_ESC IPC_REC, IPC_REC)
+    str := StrReplace(str, IPC_ESC IPC_SEP, IPC_SEP)
+    str := StrReplace(str, IPC_ESC IPC_ESC, IPC_ESC)
     return str
 }
 
 EncodeCommand(opcode, args*) {
     packet := opcode
     for arg in args {
-        packet .= Chr(1) EscapeIPC(String(arg))
+        packet .= IPC_SEP EscapeIPC(String(arg))
     }
     return packet
 }
@@ -144,7 +147,7 @@ EncodeCommand(opcode, args*) {
 EncodeBatch(commands*) {
     packet := "R1"
     for cmd in commands {
-        packet .= Chr(2) cmd
+        packet .= IPC_REC cmd
     }
     return packet
 }

--- a/Main/Util/RingBuffer.ahk
+++ b/Main/Util/RingBuffer.ahk
@@ -55,7 +55,7 @@ class RingBuffer {
         NumPut("UInt", id, this.bufPtr, pos + 4)
         NumPut("Int64", hEvent, this.bufPtr, pos + 8)
         NumPut("UInt", len, this.bufPtr, pos + 16)
-        StrPut(str, this.bufPtr + pos + 20)
+        StrPut(str, this.bufPtr + pos + 20, "UTF-16")
 
         this.SetHead(head + total)
         return true
@@ -81,7 +81,7 @@ class RingBuffer {
         id := NumGet(this.bufPtr, pos + 4, "UInt")
         hEvent := NumGet(this.bufPtr, pos + 8, "Int64")
         len := NumGet(this.bufPtr, pos + 16, "UInt")
-        str := StrGet(this.bufPtr + pos + 20)
+        str := StrGet(this.bufPtr + pos + 20, "UTF-16")
 
         total := (20 + len + 7) & ~7
         this.SetTail(tail + total)
@@ -127,22 +127,10 @@ EscapeIPC(str) {
 }
 
 UnescapeIPC(str) {
-    out := ""
-    escape := false
-    Loop Parse, str {
-        c := A_LoopField
-        if (escape) {
-            out .= c
-            escape := false
-        } else if (c == Chr(3)) {
-            escape := true
-        } else {
-            out .= c
-        }
-    }
-    if (escape)
-        out .= Chr(3)
-    return out
+    str := StrReplace(str, Chr(3) Chr(2), Chr(2))
+    str := StrReplace(str, Chr(3) Chr(1), Chr(1))
+    str := StrReplace(str, Chr(3) Chr(3), Chr(3))
+    return str
 }
 
 EncodeCommand(opcode, args*) {

--- a/Main/Util/RingBuffer.ahk
+++ b/Main/Util/RingBuffer.ahk
@@ -130,9 +130,11 @@ EscapeIPC(str) {
 }
 
 UnescapeIPC(str) {
-    str := StrReplace(str, IPC_ESC IPC_REC, IPC_REC)
-    str := StrReplace(str, IPC_ESC IPC_SEP, IPC_SEP)
-    str := StrReplace(str, IPC_ESC IPC_ESC, IPC_ESC)
+    if StrIn(str, IPC_ESC) {
+        str := StrReplace(str, IPC_ESC IPC_REC, IPC_REC)
+        str := StrReplace(str, IPC_ESC IPC_SEP, IPC_SEP)
+        str := StrReplace(str, IPC_ESC IPC_ESC, IPC_ESC)
+    }
     return str
 }
 

--- a/Main/WorkPool.ahk
+++ b/Main/WorkPool.ahk
@@ -301,8 +301,6 @@ class WorkPool {
                 SetTimer(() => this.Dispatch(), -1)
             }
         }
-        if (this.taskQueue.Size() > 0 && this.freePool.Count > 0)
-            this.Dispatch()
     }
 
     ; 移除 freePool 中已失效的 Worker（进程退出或窗口不可达），并安排补建

--- a/Main/WorkPool.ahk
+++ b/Main/WorkPool.ahk
@@ -757,11 +757,11 @@ class WorkPool {
             return
 
         commandsStr := SubStr(payload, 3)
-        for record in StrSplit(commandsStr, Chr(2)) {
+        for record in StrSplit(commandsStr, IPC_REC) {
             if (record == "")
                 continue
 
-            parts := StrSplit(record, Chr(1))
+            parts := StrSplit(record, IPC_SEP)
             if (parts.Length == 0)
                 continue
 

--- a/Thread/WorkUtil.ahk
+++ b/Thread/WorkUtil.ahk
@@ -281,10 +281,10 @@
                 return
             }
             commandsStr := SubStr(cmd, 3)
-            for record in StrSplit(commandsStr, Chr(2)) {
+            for record in StrSplit(commandsStr, IPC_REC) {
                 if (record == "")
                     continue
-                parts := StrSplit(record, Chr(1))
+                parts := StrSplit(record, IPC_SEP)
                 if (parts.Length == 0)
                     continue
                 opcode := parts[1]
@@ -326,11 +326,11 @@
             return
 
         commandsStr := SubStr(cmd, 3)
-        for record in StrSplit(commandsStr, Chr(2)) {
+        for record in StrSplit(commandsStr, IPC_REC) {
             if (record == "")
                 continue
 
-            parts := StrSplit(record, Chr(1))
+            parts := StrSplit(record, IPC_SEP)
             if (parts.Length == 0)
                 continue
 
@@ -519,10 +519,10 @@
                         try {
                             if (SubStr(payload, 1, 2) == "R1") {
                                 commandsStr := SubStr(payload, 3)
-                                for record in StrSplit(commandsStr, Chr(2)) {
+                                for record in StrSplit(commandsStr, IPC_REC) {
                                     if (record == "")
                                         continue
-                                    parts := StrSplit(record, Chr(1))
+                                    parts := StrSplit(record, IPC_SEP)
                                     if (parts.Length >= 3 && parts[1] == "GA" && parts[2] == tableIndex && parts[3] == itemIndex) {
                                         GraphPoolLog("Worker分支分配就绪", Format("tab={1} item={2}", tableIndex, itemIndex))
                                         return


### PR DESCRIPTION
1. 優化 RingBuffer.ahk 中的 UnescapeIPC 效能
   - 將原本低效的字元級別迴圈拼接 (Loop Parse) 改寫為三次原生 StrReplace。
   - 利用 AHK 底層 C++ 的替換機制，將 O(N²) 的效能瓶頸轉為極快的 O(N) 原生處理，大幅提升 IPC 處理大型負載時的解碼速度。

2. 強化 RingBuffer 字串編碼穩定性
   - 在呼叫 StrPut 與 StrGet 時，明確指定使用 "UTF-16" 編碼。
   - 避免未來 AHK 預設編碼變更或其他不可預期的資料截斷問題。

3. 修復 WorkPool.ahk 中 Dispatch 引發的 Stack Overflow 崩潰
   - 移除 Dispatch 函式結尾處，於 isDispatching 防護鎖外錯誤的遞迴呼叫。
   - 修復了當 AssignTask 分配失敗（如 PostMessage 失敗或 Tx 滿載）時，會瞬間觸發無限遞迴並導致主執行緒當機的嚴重 Bug，交由外層的 Timer 與事件迴圈重新排程處理。