### PR TITLE
refactor(hotkey): 重构窗口热键管理，区分全局和窗口级热键

### DIFF
--- a/Gui/MacroEditGui.ahk
+++ b/Gui/MacroEditGui.ahk
@@ -185,8 +185,8 @@ class MacroEditGui {
             IL_Add(ImageListID, "Images\Soft\ScreenShot.png")
         }
 
-        ; 注册快捷键热键（窗口打开期间全局有效，关闭时注销）
-        this._hkIds := WinHotkey.Register(["F5", "F6", "Delete"], ObjBindMethod(this, "_OnHotkey"))
+        ; 注册快捷键热键（仅编辑器前台时拦截，失焦时按键透传给其他程序；关闭时注销）
+        this._hkIds := WinHotkey.Register(["F5", "F6", "Delete"], ObjBindMethod(this, "_OnHotkey"), this.Gui.Hwnd)
 
         ; 注册拖拽消息监听（先注销再注册，避免重复打开时叠多个处理器）
         OnMessage(0x0201, this._lbtnHandler, 0)

--- a/Main/WindowHotkeyManager.ahk
+++ b/Main/WindowHotkeyManager.ahk
@@ -1,43 +1,76 @@
 #Requires AutoHotkey v2.0
 
 ; 窗口级热键管理器：替代原 WindowHotkeyManager 和全局 SoftHotKeyArr
-; 键盘键 → 各组件独立用 Win32 RegisterHotKey，显示时注册、隐藏时注销
+; 键盘键（带 ownerHwnd）→ AHK 原生 Hotkey + HotIfWinActive，仅在目标窗口前台时拦截，失焦时按键透传给其他程序
+; 键盘键（不带 ownerHwnd）→ Win32 RegisterHotKey，系统级拦截（供轮盘等需要全局捕获的场景）
 ; 鼠标键（Wheel/LButton）→ 集中注册一次，按需订阅/取消订阅
 
 class WinHotkey {
     static _nextId := 0xA000          ; RegisterHotKey 起始 ID
-    static _handlers := Map()         ; id → { key, callback }
+    static _handlers := Map()         ; id → { key, callback }  （RegisterHotKey 用）
+    static _ahkHkEntries := Map()     ; token → { key, winTitle }  （AHK 原生 Hotkey 用，窗口级）
     static _mouseHandlers := Map()    ; key → [callback1, callback2, ...]  （集中式鼠标热键）
     static _wmHooked := false
 
     ; ========== 键盘热键（各组件独立注册/注销）==========
 
-    ; 注册键盘热键（Win32 RegisterHotKey，系统级拦截）
-    ; 返回已注册的 ID 数组，供调用者后续 Unregister 时使用
-    static Register(keys, callback) {
-        hwnd := A_ScriptHwnd
+    ; 注册键盘热键
+    ; ownerHwnd 可选：若提供，则使用 HotIfWinActive 仅在目标窗口前台时拦截（失焦时不吞键，透传给其他程序）
+    ; 不提供 ownerHwnd 时使用 Win32 RegisterHotKey（系统级拦截，供轮盘等需要全局捕获的场景）
+    ; 返回已注册的 ID/Token 数组，供调用者后续 Unregister 时使用
+    static Register(keys, callback, ownerHwnd := 0) {
         ids := []
-        for idx, k in keys {
-            vk := GetKeyVK(k)
-            if (!vk)
-                continue
-            id := WinHotkey._nextId++
-            r := DllCall("RegisterHotKey", "Ptr", hwnd, "Int", id, "UInt", 0, "UInt", vk)
-            if (r) {
-                WinHotkey._handlers[id] := { key: k, cb: callback }
-                ids.Push(id)
+        if (ownerHwnd) {
+            ; 窗口级热键：HotIfWinActive 限定，避免全局吞键
+            winTitle := "ahk_id " ownerHwnd
+            HotIfWinActive(winTitle)
+            for idx, k in keys {
+                token := "ahk:" ownerHwnd ":" k
+                if (WinHotkey._ahkHkEntries.Has(token)) {
+                    ids.Push(token)  ; 已注册，直接返回 token
+                    continue
+                }
+                try {
+                    Hotkey(k, callback)
+                    WinHotkey._ahkHkEntries[token] := { key: k, winTitle: winTitle }
+                    ids.Push(token)
+                }
             }
-        }
-        if (WinHotkey._handlers.Count > 0 && !WinHotkey._wmHooked) {
-            OnMessage(0x0312, ObjBindMethod(WinHotkey, "_OnWMHotkey"))
-            WinHotkey._wmHooked := true
+            HotIfWinActive  ; 复位上下文，避免影响后续 Hotkey 调用
+        } else {
+            ; 全局热键：Win32 RegisterHotKey（系统级拦截）
+            hwnd := A_ScriptHwnd
+            for idx, k in keys {
+                vk := GetKeyVK(k)
+                if (!vk)
+                    continue
+                id := WinHotkey._nextId++
+                r := DllCall("RegisterHotKey", "Ptr", hwnd, "Int", id, "UInt", 0, "UInt", vk)
+                if (r) {
+                    WinHotkey._handlers[id] := { key: k, cb: callback }
+                    ids.Push(id)
+                }
+            }
+            if (WinHotkey._handlers.Count > 0 && !WinHotkey._wmHooked) {
+                OnMessage(0x0312, ObjBindMethod(WinHotkey, "_OnWMHotkey"))
+                WinHotkey._wmHooked := true
+            }
         }
         return ids
     }
 
-    ; 注销指定 ID 的键盘热键
+    ; 注销指定 ID/Token 的键盘热键
     static UnregisterId(id) {
-        if (WinHotkey._handlers.Has(id)) {
+        if (Type(id) == "String" && SubStr(id, 1, 4) == "ahk:") {
+            ; AHK 窗口级热键注销
+            if (WinHotkey._ahkHkEntries.Has(id)) {
+                entry := WinHotkey._ahkHkEntries[id]
+                HotIfWinActive(entry.winTitle)
+                try Hotkey(entry.key, "Off")
+                HotIfWinActive  ; 复位上下文
+                WinHotkey._ahkHkEntries.Delete(id)
+            }
+        } else if (WinHotkey._handlers.Has(id)) {
             DllCall("UnregisterHotKey", "Ptr", A_ScriptHwnd, "Int", id)
             WinHotkey._handlers.Delete(id)
         }
@@ -100,7 +133,7 @@ class WinHotkey {
         }
     }
 
-    ; ========== WM_HOTKEY 消息处理 ==========
+    ; ========== WM_HOTKEY 消息处理（仅 RegisterHotKey 路径使用）==========
 
     static _OnWMHotkey(wParam, lParam, msg, hwnd) {
         id := wParam & 0xFFFFFFFF


### PR DESCRIPTION
1. 新增窗口级热键模式，通过AHK原生Hotkey+HotIfWinActive实现，仅在目标窗口前台时拦截按键，失焦时自动透传按键
2. 修改MacroEditGui的热键注册，传入GUI句柄使用窗口级热键，避免全局占用快捷键影响其他程序
3. 重构WinHotkey类的Register和Unregister方法，适配两种热键模式