### PR TITLE
feat: {{ / }} 占位符號，避免被誤解析成變量

### DIFF
--- a/Main/AssetUtil.ahk
+++ b/Main/AssetUtil.ahk
@@ -1861,6 +1861,12 @@ SaveMacroCMDData(Data) {
 }
 
 GetReplaceVarText(tableItem, tableIndex, text) {
+    ; {{ / }} 跳脫：先用私有區字符佔位，避免被解析為變量，最後還原為字面量 { / }
+    static ESC_OPEN  := Chr(0xE001)   ; 佔位符：代表字面量 {
+    static ESC_CLOSE := Chr(0xE002)   ; 佔位符：代表字面量 }
+    text := StrReplace(text, "{{", ESC_OPEN)
+    text := StrReplace(text, "}}", ESC_CLOSE)
+
     matches := []      ; 存储变量名（不含花括号）
     arrayMatches := [] ; 存储数组名（不含花括号和ε）
     pos := 1
@@ -1891,6 +1897,10 @@ GetReplaceVarText(tableItem, tableIndex, text) {
             ResText := StrReplace(ResText, "{ε" arrName "}", arrValue)
         }
     }
+
+    ; 還原跳脫的字面量花括號
+    ResText := StrReplace(ResText, ESC_OPEN,  "{")
+    ResText := StrReplace(ResText, ESC_CLOSE, "}")
 
     return ResText
 }


### PR DESCRIPTION
問題：GetReplaceVarText 會把文本中所有 {xxx} 解析為變量，導致命令行語法（如 cmd /c for %i in (*) do echo {}、PowerShell 的 {} 腳本塊等）被誤解析。

解決方式：在  GetReplaceVarText 函數中加入 {{ / }} 跳脫語法